### PR TITLE
Pass context into render function

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -67,7 +67,7 @@ export default function() {
 
         if (ctx.element) {
           const renderStart = now();
-          ctx.rendered = await render(ctx.element);
+          ctx.rendered = await render(ctx.element, ctx);
           timing.render.resolve(now() - renderStart);
         }
 


### PR DESCRIPTION
This is useful for when the initial render library needs information from context (unless there's a better way of doing this).

For more context, I'm using this to thread ctx through here: https://github.com/KevinGrandon/fusion-apollo/blob/2ed111a094c18136822246a7235202f384a496ce/src/index.js#L15
This is then used for initial state here: https://github.com/KevinGrandon/fusion-apollo/blob/2ed111a094c18136822246a7235202f384a496ce/src/server.js#L7

Fixes #32 
