### PR TITLE
Do not swallow rendering errors

### DIFF
--- a/src/__tests__/__browser__/index.js
+++ b/src/__tests__/__browser__/index.js
@@ -32,3 +32,21 @@ test('app callback', async t => {
   t.equal(ctx.element, element, 'sets ctx.element');
   t.end();
 });
+
+test('throws rendering errors', async t => {
+  const element = 'hi';
+  const render = () => {
+    return new Promise(() => {
+      throw new Error('Test error');
+    });
+  };
+  const app = new App(element, render);
+  const callback = app.callback();
+
+  try {
+    await callback();
+  } catch (e) {
+    t.equal(e.message, 'Test error');
+    t.end();
+  }
+});

--- a/src/__tests__/__node__/index.js
+++ b/src/__tests__/__node__/index.js
@@ -249,3 +249,28 @@ test('renderer without element', async t => {
 
   t.end();
 });
+
+test('throws rendering errors', async t => {
+  const element = 'hi';
+  const render = () => {
+    return new Promise(() => {
+      throw new Error('Test error');
+    });
+  };
+  const app = new App(element, render);
+  const renderer = app.plugins[app.plugins.length - 1];
+
+  const ctx = {
+    path: '/',
+    element: null,
+    type: null,
+    body: null,
+  };
+
+  try {
+    await renderer(ctx, render);
+  } catch (e) {
+    t.equal(e.message, 'Test error');
+    t.end();
+  }
+});

--- a/src/client.js
+++ b/src/client.js
@@ -14,12 +14,10 @@ export default function() {
       function renderer(ctx, next) {
         const rendered = render(ctx.element);
         if (rendered instanceof Promise) {
-          return rendered
-            .then(r => {
-              ctx.rendered = r;
-              return next();
-            })
-            .catch(next);
+          return rendered.then(r => {
+            ctx.rendered = r;
+            return next();
+          });
         } else {
           ctx.rendered = rendered;
           return next();


### PR DESCRIPTION
Currently the render can fail silently, leaving us in the dark. This bubbles errors up instead of swallowing them.

Fixes #50