### PR TITLE
Fix intermittent timing test

### DIFF
--- a/src/__tests__/timing.node.js
+++ b/src/__tests__/timing.node.js
@@ -41,7 +41,7 @@ tape('timing plugin', t => {
     });
     ctx.timing.end.then(result => {
       t.equal(typeof result, 'number', 'sets end timing result');
-      t.ok(result >= 10, `result time is at least 10ms, received: ${result}ms`);
+      t.ok(result >= 1, `result time is at least 1ms, received: ${result}ms`);
       t.ok(result <= 30, 'result time is no more than 30ms');
       t.end();
     });


### PR DESCRIPTION
There is no minimum guaranteed time that microtasks take, so this often executes faster than 10ms in CI. We should probably just remove assertions against real time regardless in this test file, but just going to update it to be a value we should be able to consider safe.

Fixes #94