### PR TITLE
Execute token function on error

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -119,7 +119,9 @@ class FusionApp {
     for (const token of nonPluginTokens) {
       if (!dependedOn.has(token)) {
         throw new Error(
-          `Registered token without depending on it: ${token.toString()}`
+          `Registered token without depending on it: ${
+            token instanceof Function ? token() : String(token)
+          }`
         );
       }
     }


### PR DESCRIPTION
Tokens are functions and we get an unhelpful function when trying to show the user an error message. Executing the function will show the user which token actually has the issue.

Fixes #112