### PR TITLE
Support optional dependencies

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -52,9 +52,6 @@ declare class FusionApp {
     token: Token,
     Plugin: FusionPlugin<Deps, $Call<ExtractReturnType, Token>>
   ): aliaser<*>;
-  // register<Token: null>(token: Token, val: null): aliaser<*>;
-  // register<Token: string>(token: Token, val: string): aliaser<*>;
-  // register<Token: number>(token: Token, val: number): aliaser<*>;
   register<Token: Object>(
     token: Token,
     val: $Call<ExtractReturnType, Token>

--- a/flow.js
+++ b/flow.js
@@ -42,7 +42,9 @@ declare class FusionApp {
   renderer: any;
   enhance<Token, Deps>(
     token: Token,
-    enhancer: (item: Token) => FusionPlugin<Deps, Token>
+    enhancer: (
+      item: $Call<ExtractReturnType, Token>
+    ) => FusionPlugin<Deps, $Call<ExtractReturnType, Token>>
   ): void;
   enhance<Token>(token: Token, enhancer: (token: Token) => Token): void;
   register<Deps, Provides>(Plugin: FusionPlugin<Deps, Provides>): aliaser<*>;
@@ -57,7 +59,10 @@ declare class FusionApp {
     token: Token,
     val: $Call<ExtractReturnType, Token>
   ): aliaser<*>;
-  middleware<Deps>(deps: Deps, middleware: (Deps) => Middleware): void;
+  middleware<Deps>(
+    deps: Deps,
+    middleware: (Deps: $ObjMap<Deps, ExtractReturnType>) => Middleware
+  ): void;
   middleware(middleware: Middleware): void;
   callback(): () => Promise<void>;
   resolve(): void;

--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -195,9 +195,9 @@ tape('dependency registration with aliasing non-plugins', t => {
 
   const ValueA = 'some-value';
   const AliasedValue = 'some-aliased-value';
-  const ValueTokenA: string = createToken('ValueA');
-  const AliasedTokenA: string = createToken('AliasedTokenA');
-  const PluginB: FusionPlugin<{a: string}, BType> = createPlugin({
+  const ValueTokenA: Token<string> = createToken('ValueA');
+  const AliasedTokenA: Token<string> = createToken('AliasedTokenA');
+  const PluginB: FusionPlugin<{a: Token<string>}, BType> = createPlugin({
     deps: {
       a: ValueTokenA,
     },
@@ -211,7 +211,7 @@ tape('dependency registration with aliasing non-plugins', t => {
     },
   });
 
-  type PluginCType = FusionPlugin<{a: string}, CType>;
+  type PluginCType = FusionPlugin<{a: Token<string>}, CType>;
   const PluginC: PluginCType = createPlugin({
     deps: {
       a: ValueTokenA,

--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -3,37 +3,8 @@ import tape from 'tape-cup';
 import ClientAppFactory from '../client-app';
 import ServerAppFactory from '../server-app';
 import {createPlugin} from '../create-plugin';
-
-/* Copied from fusion-tokens/index.js */
-const tokenTypes = {
-  Required: 0,
-  Optional: 1,
-};
-function Ref() {}
-class TokenImpl {
-  name: string;
-  ref: mixed;
-  type: $Values<typeof tokenTypes>;
-
-  constructor(name: string, ref: mixed) {
-    this.name = name;
-    this.ref = ref || new Ref();
-    this.type = ref ? tokenTypes.Optional : tokenTypes.Required;
-    if (!ref) {
-      // $FlowFixMe
-      this.optional = () => new TokenImpl(name, this.ref);
-    }
-  }
-}
-
-type Token<T> = {
-  (): T,
-  optional: () => ?T,
-};
-function createToken(name: string): Token<any> {
-  // $FlowFixMe
-  return new TokenImpl(name);
-}
+import {createToken} from '../create-token';
+import type {Token} from '../create-token';
 
 const App = __BROWSER__ ? ClientAppFactory() : ServerAppFactory();
 type AType = {
@@ -53,6 +24,8 @@ const TokenB: Token<BType> = createToken('TokenB');
 const TokenC: Token<CType> = createToken('TokenC');
 const TokenD: Token<BType> = createToken('TokenD');
 const TokenEAsNullable: Token<?EType> = createToken('TokenEAsNullable');
+const TokenString: Token<string> = createToken('TokenString');
+const TokenNumber: Token<number> = createToken('TokenNumber');
 
 tape('dependency registration', t => {
   const app = new App('el', el => el);
@@ -342,8 +315,8 @@ tape('dependency registration with null value', t => {
   t.doesNotThrow(() => {
     const app = new App('el', el => el);
     // $FlowFixMe
-    app.register('something', null);
-    app.middleware({something: 'something'}, ({something}) => {
+    app.register(TokenString, null);
+    app.middleware({something: TokenString}, ({something}) => {
       t.equal(something, null, 'null provided as expected');
       return (ctx, next) => next();
     });
@@ -352,20 +325,31 @@ tape('dependency registration with null value', t => {
   t.end();
 });
 
-// tape('dependency registration with undefined value', t => {
-//   const app = new App('el', el => el);
+tape('dependency registration with optional deps', t => {
+  const app = new App('el', el => el);
 
-//   t.plan(1);
-//   const PluginC = createPlugin({
-//     deps: {optionalUndefined: TokenOptionalWithUndefinedDefault},
-//     provides: () => {
-//       t.fail('should never reach here');
-//     },
-//   });
-//   app.register(TokenC, PluginC);
-//   t.throws(app.resolve, 'unable to resolve a default value of undefined');
-//   t.end();
-// });
+  const PluginA = createPlugin({
+    deps: {
+      str: TokenString,
+      numOpt: TokenNumber.optional,
+    },
+    provides: ({str, numOpt}) => {
+      t.equals(str, 'hello', 'correct string value is provided');
+      t.equals(
+        numOpt,
+        undefined,
+        'no number value is provided for unregistered optional token'
+      );
+      return {
+        a: 'Hello',
+      };
+    },
+  });
+  app.register(TokenString, 'hello');
+  app.register(PluginA);
+  app.resolve();
+  t.end();
+});
 
 tape('dependency registration with missing deep tree dependency', t => {
   const app = new App('el', el => el);

--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -462,40 +462,6 @@ tape('dependency registration with circular dependency', t => {
   t.end();
 });
 
-// tape('dependency configuration', t => {
-//   const StringToken: string = (() => {}: any);
-//   const OtherStringToken: string = (() => {}: any);
-//   const NumberToken: number = (() => {}: any);
-//   const ObjectToken: {|
-//     a: string,
-//   |} = (() => {}: any);
-
-//   const app = new App('el', el => el);
-//   app.register(
-//     createPlugin({
-//       deps: {
-//         a: StringToken,
-//         b: OtherStringToken,
-//         c: NumberToken,
-//         d: ObjectToken,
-//       },
-//       provides: deps => {
-//         t.equal(deps.a, 'string-a');
-//         t.equal(deps.b, 'string-b');
-//         t.equal(deps.c, 5);
-//         t.deepLooseEqual(deps.d, {a: 'some-d'});
-//         t.end();
-//         return {};
-//       },
-//     })
-//   );
-//   app.register(StringToken, 'string-a');
-//   app.register(OtherStringToken, 'string-b');
-//   app.register(NumberToken, 5);
-//   app.register(ObjectToken, {a: 'some-d'});
-//   app.resolve();
-// });
-
 tape('dependency configuration with missing deps', t => {
   const StringToken: Token<string> = createToken('string-token');
   const OtherStringToken: Token<string> = createToken('other-string-token');

--- a/src/__tests__/enhance.js
+++ b/src/__tests__/enhance.js
@@ -4,18 +4,16 @@ import tape from 'tape-cup';
 import ClientAppFactory from '../client-app';
 import ServerAppFactory from '../server-app';
 import {createPlugin} from '../create-plugin';
+import {createToken} from '../create-token';
+import type {Token} from '../create-token';
+
 const App = __BROWSER__ ? ClientAppFactory() : ServerAppFactory();
 
-function createToken(name): any {
-  return () => {
-    throw new Error(`Missing dependency: ${name}`);
-  };
-}
 tape('enhancement', t => {
   const app = new App('el', el => el);
 
   type FnType = string => string;
-  const FnToken: FnType = createToken('FnType');
+  const FnToken: Token<FnType> = createToken('FnType');
   const BaseFn: FusionPlugin<void, FnType> = createPlugin({
     provides: () => {
       return arg => arg;
@@ -40,7 +38,7 @@ tape('enhancement with a plugin', t => {
   const app = new App('el', el => el);
 
   type FnType = string => string;
-  const FnToken: FnType = createToken('FnType');
+  const FnToken: Token<FnType> = createToken('FnType');
   const BaseFn: FusionPlugin<void, FnType> = createPlugin({
     provides: () => {
       return arg => arg;
@@ -68,11 +66,11 @@ tape('enhancement with a plugin', t => {
 tape('enhancement with a plugin with deps', t => {
   const app = new App('el', el => el);
 
-  const DepAToken: string = createToken('DepA');
-  const DepBToken: string = createToken('DepB');
+  const DepAToken: Token<string> = createToken('DepA');
+  const DepBToken: Token<string> = createToken('DepB');
 
   const DepA = 'test-dep-a';
-  const DepB: FusionPlugin<{a: string}, string> = createPlugin({
+  const DepB: FusionPlugin<{a: Token<string>}, string> = createPlugin({
     deps: {
       a: DepAToken,
     },
@@ -83,7 +81,7 @@ tape('enhancement with a plugin with deps', t => {
   });
 
   type FnType = string => string;
-  const FnToken: FnType = createToken('FnType');
+  const FnToken: Token<FnType> = createToken('FnType');
   const BaseFn: FusionPlugin<void, FnType> = createPlugin({
     provides: () => {
       return arg => arg;
@@ -91,7 +89,7 @@ tape('enhancement with a plugin with deps', t => {
   });
   const BaseFnEnhancer = (
     fn: FnType
-  ): FusionPlugin<{a: string, b: string}, FnType> => {
+  ): FusionPlugin<{a: Token<string>, b: Token<string>}, FnType> => {
     return createPlugin({
       deps: {
         a: DepAToken,
@@ -121,13 +119,13 @@ tape('enhancement with a plugin with deps', t => {
 tape('enhancement with a plugin with missing deps', t => {
   const app = new App('el', el => el);
 
-  const DepAToken: string = createToken('DepA');
-  const DepBToken: string = createToken('DepB');
+  const DepAToken: Token<string> = createToken('DepA');
+  const DepBToken: Token<string> = createToken('DepB');
 
   const DepB = 'test-dep-b';
 
   type FnType = string => string;
-  const FnToken: FnType = createToken('FnType');
+  const FnToken: Token<FnType> = createToken('FnType');
   const BaseFn: FusionPlugin<void, FnType> = createPlugin({
     provides: () => {
       return arg => arg;
@@ -135,7 +133,7 @@ tape('enhancement with a plugin with missing deps', t => {
   });
   const BaseFnEnhancer = (
     fn: FnType
-  ): FusionPlugin<{a: string, b: string}, FnType> => {
+  ): FusionPlugin<{a: Token<string>, b: Token<string>}, FnType> => {
     return createPlugin({
       deps: {
         a: DepAToken,
@@ -157,6 +155,6 @@ tape('enhancement with a plugin with missing deps', t => {
     t.end();
     return (ctx, next) => next();
   });
-  t.throws(() => app.resolve(), /Missing dependency: DepA/);
+  t.throws(() => app.resolve(), /Cannot resolve to a value for token: DepA/);
   t.end();
 });

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -1,8 +1,11 @@
 /* @flow */
+
 import test, {run} from './test-helper';
 import ClientAppFactory from '../client-app';
 import ServerAppFactory from '../server-app';
 import {createPlugin} from '../create-plugin';
+import {createToken} from '../create-token';
+import type {Token} from '../create-token';
 
 const App = __BROWSER__ ? ClientAppFactory() : ServerAppFactory();
 type AType = {
@@ -11,8 +14,9 @@ type AType = {
 type BType = () => {
   b: string,
 };
-const TokenA: AType = (() => 'TokenA': any);
-const TokenB: BType = (() => 'TokenB': any);
+const TokenA: Token<AType> = createToken('TokenA');
+const TokenB: Token<BType> = createToken('TokenB');
+const TokenString: Token<string> = createToken('TokenString');
 
 function delay() {
   return new Promise(resolve => {
@@ -201,16 +205,15 @@ test('app.register - middleware execution respects dependency order', async t =>
 });
 
 test('app.middleware with dependencies', async t => {
-  const TokenA = 'TokenA';
   const element = 'hi';
   const renderFn = el => {
     return el;
   };
   const app = new App(element, renderFn);
   let called = false;
-  app.register(TokenA, 'Something');
-  app.middleware({TokenA}, deps => {
-    t.equal(deps.TokenA, 'Something');
+  app.register(TokenString, 'Something');
+  app.middleware({TokenString}, deps => {
+    t.equal(deps.TokenString, 'Something');
     return (ctx, next) => {
       called = true;
       return next();

--- a/src/__tests__/timing.js
+++ b/src/__tests__/timing.js
@@ -1,9 +1,11 @@
 // @flow
+
 import test from 'tape-cup';
 import ClientAppFactory from '../client-app';
 import ServerAppFactory from '../server-app';
 import {run} from './test-helper';
 import {TimingToken} from '../plugins/timing';
+
 const App = __BROWSER__ ? ClientAppFactory() : ServerAppFactory();
 
 test('timing plugin', async t => {

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -49,12 +49,12 @@ class FusionApp {
     const resolving = new Set(); // Token.ref || Token
     const registered = this.registered; // Token.ref || Token -> {value, aliases, enhancers}
     const resolvedPlugins = []; // Plugins
-    const allAliases = new Set();
+    const allAliases = new Set(); // Token.ref || Token
     const resolveToken = (token, tokenAliases) => {
       // Base: if we have already resolved the type, return it
       if (tokenAliases && tokenAliases.has(token)) {
         const newToken = tokenAliases.get(token);
-        allAliases.add([token, newToken]);
+        allAliases.add([token.ref || token, newToken.ref || newToken]);
         token = newToken;
       }
       if (resolved.has(token.ref || token)) {
@@ -129,9 +129,9 @@ class FusionApp {
       resolveToken(this.plugins[i]);
     }
     for (const aliasPair of allAliases) {
-      const [sourceToken, destToken] = aliasPair;
-      if (dependedOn.has(sourceToken)) {
-        dependedOn.add(destToken);
+      const [sourceTokenRef, destTokenRef] = aliasPair;
+      if (dependedOn.has(sourceTokenRef)) {
+        dependedOn.add(destTokenRef);
       }
     }
     for (const token of nonPluginTokens) {

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -1,0 +1,32 @@
+// @flow
+
+/* Copied from fusion-tokens/index.js */
+export const TokenType = {
+  Required: 0,
+  Optional: 1,
+};
+function Ref() {}
+class TokenImpl {
+  name: string;
+  ref: mixed;
+  type: $Values<typeof TokenType>;
+
+  constructor(name: string, ref: mixed) {
+    this.name = name;
+    this.ref = ref || new Ref();
+    this.type = ref ? TokenType.Optional : TokenType.Required;
+    if (!ref) {
+      // $FlowFixMe
+      this.optional = new TokenImpl(name, this.ref);
+    }
+  }
+}
+
+export type Token<T> = {
+  (): T,
+  optional: () => ?T,
+};
+export function createToken(name: string): Token<any> {
+  // $FlowFixMe
+  return new TokenImpl(name);
+}

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -1,12 +1,11 @@
 // @flow
 
-/* Copied from fusion-tokens/index.js */
 export const TokenType = {
   Required: 0,
   Optional: 1,
 };
 function Ref() {}
-class TokenImpl {
+export class TokenImpl {
   name: string;
   ref: mixed;
   type: $Values<typeof TokenType>;

--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,4 @@ export {
 
 export {RenderToken, ElementToken} from './tokens';
 export {createPlugin} from './create-plugin';
+export {createToken} from './create-token';

--- a/src/plugins/timing.js
+++ b/src/plugins/timing.js
@@ -1,7 +1,8 @@
 /* @flow */
 import {createPlugin} from '../create-plugin';
-
 import {memoize} from '../memoize';
+import {createToken} from '../create-token';
+import type {Token} from '../create-token';
 
 type Deferred<T> = {
   promise: Promise<T>,
@@ -31,7 +32,7 @@ const timing: TimingPlugin = {
   from: memoize(() => new Timing()),
 };
 
-export const TimingToken: TimingPlugin = (() => {}: any);
+export const TimingToken: Token<TimingPlugin> = createToken('TimingToken');
 
 function middleware(ctx, next) {
   ctx.memoized = new Map();

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,6 +1,4 @@
-export const RenderToken = () => {
-  throw new Error('Missing required value for RenderToken');
-};
-export const ElementToken = () => {
-  throw new Error('Missing required value for ElementToken');
-};
+import {createToken} from './create-token';
+
+export const RenderToken = createToken('RenderToken');
+export const ElementToken = createToken('ElementToken');


### PR DESCRIPTION
Fixes #95.  Implements proposed **Option 1**:

```js
// Defining the token
import {createToken} from 'fusion-tokens';
import type {Token} from 'fusion-tokens';

type Fetch = (input: string | Request, init?: RequestOptions) => Promise<Response>;
export const FetchToken: Token<Fetch> = createTaoken('FetchToken');

// Using the token
import {createPlugin} from 'fusion-core';
export default createPlugin({
  deps: {
    fetch: FetchToken, // required token example
    logger: LoggerToken.optional, // optional token example
  },
});
```