### PR TITLE
Scope optional Tokens to `undefined` or provided value

### DIFF
--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -383,18 +383,30 @@ tape('dependency registration with null value', t => {
 tape('dependency registration with optional deps', t => {
   const app = new App('el', el => el);
 
+  const checkString = (s: string): void => {
+    t.equals(s, 'hello', 'correct string value is provided');
+  };
+  const checkNumUndefined = (n: void | number): void => {
+    t.equals(
+      n,
+      undefined,
+      'no number value is provided for unregistered optional token'
+    );
+  };
+
+  type Deps = {
+    str: string,
+    numOpt: void | number,
+  };
   const PluginA = createPlugin({
     deps: {
       str: TokenString,
       numOpt: TokenNumber.optional,
     },
-    provides: ({str, numOpt}) => {
-      t.equals(str, 'hello', 'correct string value is provided');
-      t.equals(
-        numOpt,
-        undefined,
-        'no number value is provided for unregistered optional token'
-      );
+    provides: ({str, numOpt}: Deps) => {
+      checkString(str);
+      checkNumUndefined(numOpt);
+
       return {
         a: 'Hello',
       };

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -23,7 +23,7 @@ export class TokenImpl {
 
 export type Token<T> = {
   (): T,
-  optional: () => ?T,
+  optional: () => void | T,
 };
 export function createToken(name: string): Token<any> {
   // $FlowFixMe


### PR DESCRIPTION
Fixes #129:

> #### Problem/Rationale
> 
> Optional Tokens are not as explicit as they should be, and should allow for only:
> * `undefined` - no value registered
> * `T` - value that was registered
> 
> Today, they are [maybe](https://flow.org/en/docs/types/maybe/) values (which allows `nulls`).
> 
> #### Solution/Change/Deliverable
> 
> Change type signature of `Token<T>` to:
> 
> ```js
> type Token<T> = {
>   (): T,
>   optional: () => void | T,
> };
> ```
> 