### PR TITLE
Skip fusion-core flow file generation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-dist/index.js.flow

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+dist/index.js.flow

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint . --ignore-path .gitignore",
-    "transpile": "npm run clean && cup build",
+    "transpile": "npm run clean && cup build --skip-flow",
     "build-test": "rm -rf dist-tests && cup build-tests",
     "just-test":
       "unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "fusion-core",
-  "description": "A generic entry point class for FusionJS applications that is used by the FusionJS runtime.",
+  "description":
+    "A generic entry point class for FusionJS applications that is used by the FusionJS runtime.",
   "version": "0.3.6",
   "license": "MIT",
   "repository": "fusionjs/fusion-core",
-  "files": [
-    "dist",
-    "flow-typed",
-    "src"
-  ],
+  "files": ["dist", "flow-typed"],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "browser": {
@@ -45,7 +42,8 @@
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",
-    "just-test": "unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
+    "just-test":
+      "unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "cover": "npm run build-test && npm run just-cover",
     "just-cover": "nyc --reporter=html npm run just-test",


### PR DESCRIPTION
Due to the create-universal-package upgrade this package now exports an index.js.flow which flow will attempt to use for flowtyping. This file currently does not export any of the types within flow.js, or flow-typed/fusion-core.js, so this causes flow to fail. Not generating this file should allow us to have flow passing as before.

I'm not sure if this gets us anything for type safety when importing fusion-core, but it does not cause flow to fail for other plugins. Ideally we move flowtypes into JS files for this package.