### PR TITLE
Disambiguate enhance type

### DIFF
--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -50,13 +50,7 @@ declare module 'fusion-core' {
     plugins: Array<any>;
     renderer: any;
     cleanup(): Promise<any>;
-    enhance<Token, Deps>(
-      token: Token,
-      enhancer: (
-        item: $Call<ExtractReturnType, Token>
-      ) => FusionPlugin<Deps, $Call<ExtractReturnType, Token>>
-    ): void;
-    enhance<Token>(token: Token, enhancer: (token: Token) => Token): void;
+    enhance<Token, Deps>(token: Token, enhancer: Function): void;
     register<Deps, Provides>(Plugin: FusionPlugin<Deps, Provides>): aliaser<*>;
     register<Token, Deps>(
       token: Token,

--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -44,7 +44,7 @@ declare module 'fusion-core' {
   declare type MemoizeFn<A> = (ctx: Context) => A;
   declare export function memoize<A>(fn: MemoizeFn<A>): MemoizeFn<A>;
   declare class FusionApp {
-    constructor<Element>(element: Element, render: (Element) => any): FusionApp;
+    constructor<Element>(element: Element, render: *): FusionApp;
     cleanups: Array<cleanupFn>;
     registered: Map<any, any>;
     plugins: Array<any>;


### PR DESCRIPTION
Existing type definitions are ambiguous and cause errors. This replaces them with a looser type