### PR TITLE
Proposal: Implement additional SSR detection and control

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,17 +635,13 @@ app.enhance(FetchToken, fetch => {
 });
 ```
 
-#### Controling SSR behavior
+#### Controlling SSR behavior
 
-You can control SSR behavior by enhancing the SSRDeciderToken. This will give you the ability to apply custom logic around which routes go through the renderer.
+You can control SSR behavior by enhancing the SSRDeciderToken. This will give you the ability to apply custom logic around which routes go through the renderer. You may enhance the SSRDeciderToken with either a function, or a plugin if you need dependencies.
 
 ```js
 import {SSRDeciderToken} from 'fusion-core';
-const SSRDeciderEnhancer = ssrDecider =>
-  createPlugin({
-    provides: () => ctx => {
-      return ssrDecider(ctx) && !ctx.path.startsWith('/path/to/disable/ssr');
-    },
-  });
-app.enhance(SSRDeciderToken, SSRDeciderEnhancer);
+app.enhance(SSRDeciderToken, decide => ctx =>
+  decide(ctx) && !ctx.path.match(/ignore-ssr-route/)
+);
 ```

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ app.enhance(FetchToken, fetch => {
 
 #### Controlling SSR behavior
 
-You can control SSR behavior by enhancing the SSRDeciderToken. This will give you the ability to apply custom logic around which routes go through the renderer. You may enhance the SSRDeciderToken with either a function, or a plugin if you need dependencies.
+By default we do not perfrom SSR for any paths that match the following extensions: js, gif, jpg, png, pdf and json. You can control SSR behavior by enhancing the SSRDeciderToken. This will give you the ability to apply custom logic around which routes go through the renderer. You may enhance the SSRDeciderToken with either a function, or a plugin if you need dependencies.
 
 ```js
 import {SSRDeciderToken} from 'fusion-core';

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ app.register(RenderToken, render);
 The render token is used to register the render function with the fusion app. This is a function that knows how to
 render your application on the server/browser, and allows `fusion-core` to remain agnostic of the virtualdom library.
 
+##### SSRDeciderEnhancer
+
+```js
+import App, {SSRDeciderToken} from 'fusion-core';
+app.enhance(SSRDeciderToken, SSRDeciderEnhancer);
+```
+
+Ths SSRDeciderToken can be enhanced to control server rendering logic.
+
 ---
 
 #### Plugin
@@ -624,4 +633,19 @@ app.enhance(FetchToken, fetch => {
     },
   });
 });
+```
+
+#### Controling SSR behavior
+
+You can control SSR behavior by enhancing the SSRDeciderToken. This will give you the ability to apply custom logic around which routes go through the renderer.
+
+```js
+import {SSRDeciderToken} from 'fusion-core';
+const SSRDeciderEnhancer = ssrDecider =>
+  createPlugin({
+    provides: () => ctx => {
+      return ssrDecider(ctx) && !ctx.path.startsWith('/path/to/disable/ssr');
+    },
+  });
+app.enhance(SSRDeciderToken, SSRDeciderEnhancer);
 ```

--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -86,4 +86,5 @@ declare module 'fusion-core' {
   declare export function unescape(str: string): string;
   declare export var RenderToken: (Element: any) => string;
   declare export var ElementToken: any;
+  declare export var SSRDeciderToken: any;
 }

--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -13,6 +13,7 @@ import App, {
   syncChunkPaths,
   RenderToken,
   ElementToken,
+  SSRDeciderToken,
   createPlugin,
 } from '../index.js';
 
@@ -44,6 +45,7 @@ test('fusion-core api', t => {
   t.ok(syncChunkPaths, 'exports syncChunkPaths');
   t.ok(RenderToken, 'exports RenderToken');
   t.ok(ElementToken, 'exports ElementToken');
+  t.ok(SSRDeciderToken, 'exports SSRDeciderToken');
   t.ok(createPlugin, 'exports createPlugin');
   t.end();
 });

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -1,6 +1,8 @@
 import test from 'tape-cup';
 import App, {html} from '../index';
 import {run} from './test-helper';
+import {SSRDeciderToken} from '../tokens';
+import {createPlugin} from '../create-plugin';
 
 test('ssr with accept header', async t => {
   const flags = {render: false};
@@ -73,6 +75,61 @@ test('ssr without valid accept header', async t => {
     t.notok(ctx.body, 'does not set ctx.body');
     t.ok(!flags.render, 'does not call render');
     t.notok(ctx.body, 'does not render ctx.body to string');
+  } catch (e) {
+    t.ifError(e, 'does not error');
+  }
+  t.end();
+});
+
+test('disable SSR by composing SSRDecider', async t => {
+  const flags = {render: false};
+  const element = 'hi';
+  const render = () => {
+    flags.render = true;
+  };
+
+  function buildApp() {
+    const app = new App(element, render);
+
+    app.middleware((ctx, next) => {
+      ctx.body = '_NO_SSR_';
+      return next();
+    });
+
+    const SSRDeciderEnhancer = ssrDecider => {
+      return createPlugin({
+        provides: () => {
+          return ctx => {
+            return (
+              ssrDecider(ctx) &&
+              !ctx.path.startsWith('/foo') &&
+              !ctx.path.startsWith('/bar')
+            );
+          };
+        },
+      });
+    };
+    app.enhance(SSRDeciderToken, SSRDeciderEnhancer);
+    return app;
+  }
+
+  try {
+    let initialCtx = {
+      path: '/foo',
+    };
+    const ctx = await run(buildApp(), initialCtx);
+
+    t.notok(ctx.element, 'non-ssr route does not set ctx.element');
+    t.notok(ctx.type, 'non-ssr route does not set ctx.type');
+    t.ok(!flags.render, 'non-ssr route does not call render');
+    t.equals(ctx.body, '_NO_SSR_', 'can set body in plugin during non-ssr');
+
+    let validSSRPathCtx = {
+      path: '/some-path',
+    };
+    const renderCtx = await run(buildApp(), validSSRPathCtx);
+    t.equals(renderCtx.element, element, 'ssr route sets ctx.element');
+    t.equals(renderCtx.type, 'text/html', 'ssr route sets ctx.type');
   } catch (e) {
     t.ifError(e, 'does not error');
   }

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -180,6 +180,48 @@ test('disable SSR by composing SSRDecider with a function', async t => {
   t.end();
 });
 
+test('SSR extension handling', async t => {
+  const extensionToSSRSupported = {
+    js: false,
+    gif: false,
+    jpg: false,
+    png: false,
+    pdf: false,
+    json: false,
+    html: true,
+  };
+
+  const flags = {render: false};
+  const element = 'hi';
+  const render = () => {
+    flags.render = true;
+  };
+
+  function buildApp() {
+    const app = new App(element, render);
+    return app;
+  }
+
+  try {
+    for (let i in extensionToSSRSupported) {
+      flags.render = false;
+      let initialCtx = {
+        path: `/some-path.${i}`,
+      };
+      await run(buildApp(), initialCtx);
+      const shouldSSR = extensionToSSRSupported[i];
+      t.equals(
+        flags.render,
+        shouldSSR,
+        `extension of ${i} should ${shouldSSR ? '' : 'not'} have ssr`
+      );
+    }
+  } catch (e) {
+    t.ifError(e, 'does not error');
+  }
+  t.end();
+});
+
 test('HTML escaping works', async t => {
   const element = 'hi';
   const render = el => el;

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -1,6 +1,7 @@
 import {createPlugin} from './create-plugin';
 import {createToken, TokenType, TokenImpl} from './create-token';
-import {ElementToken, RenderToken} from './tokens';
+import {ElementToken, RenderToken, SSRDeciderToken} from './tokens';
+import {SSRDecider} from './plugins/ssr';
 
 class FusionApp {
   constructor(el, render) {
@@ -9,6 +10,7 @@ class FusionApp {
     this.cleanups = [];
     el && this.register(ElementToken, el);
     render && this.register(RenderToken, render);
+    this.register(SSRDeciderToken, SSRDecider);
   }
   register(token, value) {
     if (token && token.__plugin__) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,6 @@ export {
   syncChunkPaths,
 } from './virtual/index.js';
 
-export {RenderToken, ElementToken} from './tokens';
+export {RenderToken, ElementToken, SSRDeciderToken} from './tokens';
 export {createPlugin} from './create-plugin';
 export {createToken} from './create-token';

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -7,7 +7,7 @@ const SSRDecider = createPlugin({
     return ctx => {
       // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
       // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
-      if (ctx.path.match(/\.js$/)) return false;
+      if (ctx.path.match(/\.(js|gif|jpg|png|pdf|json)$/)) return false;
       // The Accept header is a good proxy for whether SSR should happen
       // Requesting an HTML page via the browser url bar generates a request with `text/html` in its Accept headers
       // XHR/fetch requests do not have `text/html` in the Accept headers

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -1,9 +1,27 @@
 import path from 'path';
+import {createPlugin} from '../create-plugin';
 import {escape, consumeSanitizedHTML} from '../sanitization';
 
-export default function createSSRPlugin({element}) {
+const SSRDecider = createPlugin({
+  provides: () => {
+    return ctx => {
+      // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
+      // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
+      if (ctx.path.match(/\.js$/)) return false;
+      // The Accept header is a good proxy for whether SSR should happen
+      // Requesting an HTML page via the browser url bar generates a request with `text/html` in its Accept headers
+      // XHR/fetch requests do not have `text/html` in the Accept headers
+      if (!ctx.headers.accept) return false;
+      if (!ctx.headers.accept.includes('text/html')) return false;
+      return true;
+    };
+  },
+});
+export {SSRDecider};
+
+export default function createSSRPlugin({element, ssrDecider}) {
   return async function ssrPlugin(ctx, next) {
-    if (!isSSR(ctx)) return next();
+    if (!ssrDecider(ctx)) return next();
 
     const template = {
       htmlAttrs: {},
@@ -53,19 +71,6 @@ export default function createSSRPlugin({element}) {
       '</html>',
     ].join('');
   };
-}
-
-function isSSR(ctx) {
-  // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
-  // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
-  if (ctx.path.match(/\.js$/)) return false;
-  // The Accept header is a good proxy for whether SSR should happen
-  // Requesting an HTML page via the browser url bar generates a request with `text/html` in its Accept headers
-  // XHR/fetch requests do not have `text/html` in the Accept headers
-  if (!ctx.headers.accept) return false;
-  if (!ctx.headers.accept.includes('text/html')) return false;
-  //TODO(#45): Investigate alternatives to checking accept header
-  return true;
 }
 
 function getCoreGlobals(ctx) {

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -4,7 +4,7 @@ import {compose} from './compose.js';
 import Timing, {TimingToken} from './plugins/timing';
 import BaseApp from './base-app';
 import serverRenderer from './plugins/server-renderer';
-import {RenderToken, ElementToken} from './tokens';
+import {RenderToken, ElementToken, SSRDeciderToken} from './tokens';
 import ssrPlugin from './plugins/ssr';
 
 export default function(): Class<FusionApp> {
@@ -16,7 +16,10 @@ export default function(): Class<FusionApp> {
       super(el, render);
       this._app = new Koa();
       this.register(TimingToken, Timing);
-      this.middleware({element: ElementToken}, ssrPlugin);
+      this.middleware(
+        {element: ElementToken, ssrDecider: SSRDeciderToken},
+        ssrPlugin
+      );
     }
     resolve() {
       this.middleware(

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -2,3 +2,4 @@ import {createToken} from './create-token';
 
 export const RenderToken = createToken('RenderToken');
 export const ElementToken = createToken('ElementToken');
+export const SSRDeciderToken = createToken('SSRDeciderToken');


### PR DESCRIPTION
This implements two SSR detection features.

* **Additional non-SSR whitelisted extensions**
Adds the following extensions: (js|gif|jpg|png|pdf|json)

* **SSRDeciderToken for enhancing SSR logic**
Exports our current SSR logic as a new token, SSRDeciderToken, which can be enhanced through the DI system. This is a change which keeps our API surface fairly small, isn't difficult to support, and allows folks to control server rendering while we iterate on a future solution.

For more discussion and a breakdown of supported URIs see: https://github.com/fusionjs/fusion-core/issues/116#issuecomment-369430656

Fixes #45 
Fixes #116