### PR TITLE
Encapsulate all types and imports in the 'fusion-core' module

### DIFF
--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -1,17 +1,16 @@
 /* @flow */
-import type {Context as KoaContext} from 'koa';
-
-// TODO(#61): Type checking here isn't very good, as it allows you to
-// alias tokens that are not of the exact same type.
-type aliaser<Token> = {
-  alias: (sourceToken: Token, destToken: Token) => aliaser<*>,
-};
-
-type cleanupFn = (thing: any) => Promise<any>;
-
-type ExtractReturnType = <V>(() => V) => V;
 
 declare module 'fusion-core' {
+  import type {Context as KoaContext} from 'koa';
+
+  // TODO(#61): Type checking here isn't very good, as it allows you to
+  // alias tokens that are not of the exact same type.
+  declare type aliaser<Token> = {
+    alias: (sourceToken: Token, destToken: Token) => aliaser<*>,
+  };
+  declare type cleanupFn = (thing: any) => Promise<any>;
+  declare type ExtractReturnType = <V>(() => V) => V;
+
   declare var __NODE__: Boolean;
   declare var __BROWSER__: Boolean;
   declare export type SSRContext = {

--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 declare module 'fusion-core' {
+  // $FlowFixMe
   import type {Context as KoaContext} from 'koa';
 
   // TODO(#61): Type checking here isn't very good, as it allows you to
@@ -68,7 +69,7 @@ declare module 'fusion-core' {
     callback(): () => Promise<void>;
     resolve(): void;
   }
-  declare export default typeof FusionApp;
+  declare export default typeof FusionApp
   declare export function createPlugin<Deps, Service>(
     options: FusionPlugin<Deps, Service>
   ): FusionPlugin<Deps, Service>;

--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -69,7 +69,7 @@ declare module 'fusion-core' {
     callback(): () => Promise<void>;
     resolve(): void;
   }
-  declare export default typeof FusionApp
+  declare export default typeof FusionApp;
   declare export function createPlugin<Deps, Service>(
     options: FusionPlugin<Deps, Service>
   ): FusionPlugin<Deps, Service>;


### PR DESCRIPTION
Fixes the issue where Koa type definitions were not visible to consumers of `fusion-core` type definitions:

<img width="390" alt="screen shot 2018-03-22 at 1 13 20 pm" src="https://user-images.githubusercontent.com/3497835/37795867-e82428e0-2dd2-11e8-8566-f357d6b3e50b.png">
