### PR TITLE
Display more context when missing dependencies

### DIFF
--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -474,6 +474,31 @@ tape('dependency registration with circular dependency', t => {
 });
 
 tape('dependency configuration with missing deps', t => {
+  const ParentToken: Token<string> = createToken('parent-token');
+  const StringToken: Token<string> = createToken('string-token');
+  const OtherStringToken: Token<string> = createToken('other-string-token');
+
+  const app = new App('el', el => el);
+  app.register(
+    ParentToken,
+    createPlugin({
+      deps: {
+        a: StringToken,
+        b: OtherStringToken,
+      },
+      provides: () => {
+        t.fail('should not get here');
+        return 'service';
+      },
+    })
+  );
+  app.register(StringToken, 'string-a');
+  t.throws(() => app.resolve(), 'throws if dependencies are not configured');
+  t.throws(() => app.resolve(), /\nDependent tokens are: parent-token/);
+  t.end();
+});
+
+tape('error message when dependent plugin does not have token', t => {
   const StringToken: Token<string> = createToken('string-token');
   const OtherStringToken: Token<string> = createToken('other-string-token');
 
@@ -491,7 +516,7 @@ tape('dependency configuration with missing deps', t => {
     })
   );
   app.register(StringToken, 'string-a');
-  t.throws(() => app.resolve(), 'throws if dependencies are not configured');
+  t.throws(() => app.resolve(), /\nDependent tokens are: UnnamedPlugin/);
   t.end();
 });
 

--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -494,7 +494,10 @@ tape('dependency configuration with missing deps', t => {
   );
   app.register(StringToken, 'string-a');
   t.throws(() => app.resolve(), 'throws if dependencies are not configured');
-  t.throws(() => app.resolve(), /\nDependent tokens are: parent-token/);
+  t.throws(
+    () => app.resolve(),
+    /required by plugins registered with tokens: "parent-token"/
+  );
   t.end();
 });
 
@@ -516,7 +519,10 @@ tape('error message when dependent plugin does not have token', t => {
     })
   );
   app.register(StringToken, 'string-a');
-  t.throws(() => app.resolve(), /\nDependent tokens are: UnnamedPlugin/);
+  t.throws(
+    () => app.resolve(),
+    /required by plugins registered with tokens: "UnnamedPlugin"/
+  );
   t.end();
 });
 

--- a/src/__tests__/enhance.js
+++ b/src/__tests__/enhance.js
@@ -154,6 +154,9 @@ tape('enhancement with a plugin with missing deps', t => {
     t.end();
     return (ctx, next) => next();
   });
-  t.throws(() => app.resolve(), /Cannot resolve to a value for token: DepA/);
+  t.throws(
+    () => app.resolve(),
+    /Could not resolve token: "DepA", which is required by plugins registered with tokens: "EnhancerOf<FnType>"./
+  );
   t.end();
 });


### PR DESCRIPTION
This updates error messages to provide more context around which Plugin was attempting to require a missing dependency.

For a normal missing dependency:
> Could not resolve token: "DepA", which is required by plugins registered with tokens: "MyParentToken". Did you forget to register a value for "DepA"?

For a missing dependency used by an enhancer plugin:
> Could not resolve token: "DepA", which is required by plugins registered with tokens: "EnhancerOf\<MyEnhancedToken>". Did you forget to register a value for "DepA"?
