### PR TITLE
Fix fusion-core libdef type definitions file

### DIFF
--- a/flow-typed/fusion-core.js
+++ b/flow-typed/fusion-core.js
@@ -28,11 +28,11 @@ declare module 'fusion-core' {
     optional: () => void | T,
   };
   declare export type Context = SSRContext | KoaContext;
-  declare export type FusionPlugin<Deps, Service> = {
+  declare export type FusionPlugin<Deps: {}, Service> = {
     deps?: Deps,
-    provides?: (Deps: $ObjMap<Deps, ExtractReturnType>) => Service,
+    provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,
     middleware?: (
-      Deps: $ObjMap<Deps, ExtractReturnType>,
+      Deps: $ObjMap<Deps & {}, ExtractReturnType>,
       Service: Service
     ) => Middleware,
     cleanup?: (service: Service) => Promise<any>,
@@ -87,4 +87,6 @@ declare module 'fusion-core' {
   declare export var RenderToken: (Element: any) => string;
   declare export var ElementToken: any;
   declare export var SSRDeciderToken: any;
+
+  declare export function compose(middleware: Array<Middleware>): Middleware;
 }


### PR DESCRIPTION
Fixes [#678](https://app.zenhub.com/workspace/o/uber-web/web-platform-tasks/issues/678)

> #### Problem/Rationale
> 
> Type definition for `FusionPlugin<Deps, Service>` breaks on `$ObjMap` call if `Deps` resolves to `undefined` (or non-object).
> 
> #### Solution/Change/Deliverable
> 
> Ensure that the `$ObjMap` call is invoked on type `Object`.

See a live example of the error: [here](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoALgTwA4FMwCiAHugE4CGAxugEq7oCupAdgCo74C8YAPAGoA+ABRCAlGE4CwfcZOkBuDBzAAxBgGcAlnGYAFGAwDmm5jwAiubOoA0YAMq5SAN02VcU7gG9UYMABNLdQB+AC4wCytrHzBsUjgXAOCwoQj1MIASAHkAIwArAFlybHNA22IyKlp6JjYOAVkpB2dXXCiAX0VfLrBUShhydXVVDW1mAEFsbDBvX1JcY3V0RxLI+0cXN2F9IxMwtS0dbeNTVNsmjfdRMMXSE0Np6NnqljAAIgALXBh4V86wNtQHVQqCgDGY1FGYDg2HQo3I30wdAWS1I6jGRxMQmiRWwexGOgm2CivnUcAAtrgMcxQsMDnoDMceCBbCABKgrmAnHBNH4Hr5NFAhKSKVTxDMujiAHRzZGOIXkykMkyiP4AjpAA).