### PR TITLE
Restore rendering with body to allow for react-router SSR redirects

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -281,9 +281,9 @@ test('SSR with redirects downstream', async t => {
   try {
     const ctx = await run(app);
     t.equal(ctx.status, 302, 'sends 302 status code');
-    t.notok(ctx.rendered, 'does not render');
+    t.ok(ctx.rendered, 'should call render for SSR-based component redirects');
     t.equal(typeof ctx.body, 'string');
-    t.notok(flags.render, 'does not call render');
+    t.ok(flags.render, 'calls render for SSR-based component redirects');
   } catch (e) {
     t.ifError(e, 'should not error');
   }

--- a/src/plugins/server-renderer.js
+++ b/src/plugins/server-renderer.js
@@ -5,8 +5,8 @@ export default function getRendererPlugin({render, timing}) {
     const timer = timing.from(ctx);
     timer.downstream.resolve(now() - timer.start);
 
-    let renderTime = null;
-    if (ctx.element && !ctx.body) {
+    let renderTime = 0;
+    if (ctx.element) {
       const renderStart = now();
       ctx.rendered = await render(ctx.element);
       renderTime = now() - renderStart;


### PR DESCRIPTION
This is required to properly redirect users when using react-router. If we want to disable rendering for routes with a body, we should use another flag or key on context. This would also prevent a breaking change, requiring a major version release.

Fixes #197

Instead we're looking at going with: https://github.com/fusionjs/fusion-plugin-react-router/pull/126