### PR TITLE
Lock down cleanup return type

### DIFF
--- a/src/base-app.js.flow
+++ b/src/base-app.js.flow
@@ -15,7 +15,7 @@ declare class FusionApp {
   registered: Map<any, any>;
   plugins: Array<any>;
   renderer: any;
-  cleanup(): Promise<any>;
+  cleanup(): Promise<void>;
   enhance<Token, Deps>(token: Token, enhancer: Function): void;
   register<Deps, Provides>(Plugin: FusionPlugin<Deps, Provides>): aliaser<*>;
   register<Token, Deps>(

--- a/src/flow/flow-fixtures.js
+++ b/src/flow/flow-fixtures.js
@@ -112,3 +112,8 @@ if (extractedFullMiddleware) {
   // $FlowFixMe
   extractedFullMiddleware({str: 'hello'}); // should fail
 }
+
+/*   - Case: Cleanup should be covered */
+async function cleanup() {
+  await someApp.cleanup();
+}

--- a/src/types.js
+++ b/src/types.js
@@ -45,11 +45,11 @@ export type FusionPlugin<Deps, Service> = {
     Deps: $ObjMap<Deps & {}, ExtractReturnType>,
     Service: Service
   ) => Middleware,
-  cleanup?: (service: Service) => Promise<any>,
+  cleanup?: (service: Service) => Promise<void>,
 };
 
 export type aliaser<Token> = {
   alias: (sourceToken: Token, destToken: Token) => aliaser<Token>,
 };
 
-export type cleanupFn = (thing: any) => Promise<any>;
+export type cleanupFn = (thing: any) => Promise<void>;


### PR DESCRIPTION
Right now any call to app.cleanup results in uncovered code due to the any. Instead prefer coverage over flexibiltiy, and force apps to manually cast if needed. In the future we can open this up more if apps start using this for other things.