### PR TITLE
Fix flow typing for getEnv

### DIFF
--- a/src/flow/flow-fixtures.js
+++ b/src/flow/flow-fixtures.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {createPlugin, createToken} from '../../src/index.js';
+import {createPlugin, createToken, getEnv} from '../../src/index.js';
 import BaseApp from '../../src/base-app';
 
 import type {Context, FusionPlugin, Middleware, Token} from '../types.js';
@@ -116,4 +116,26 @@ if (extractedFullMiddleware) {
 /*   - Case: Cleanup should be covered */
 async function cleanup() {
   await someApp.cleanup();
+}
+
+/*   - Case: getEnv typing */
+async function checkEnv() {
+  const {
+    rootDir,
+    env,
+    prefix,
+    assetPath,
+    baseAssetPath,
+    cdnUrl,
+    webpackPublicPath,
+  } = getEnv();
+  return {
+    rootDir,
+    env,
+    prefix,
+    assetPath,
+    baseAssetPath,
+    cdnUrl,
+    webpackPublicPath,
+  };
 }

--- a/src/get-env.js
+++ b/src/get-env.js
@@ -25,7 +25,7 @@ export function loadEnv() {
   assert(!cdnUrl.endsWith('/'), 'CDN_URL must not end with /');
 
   const assetPath = `${prefix}${baseAssetPath}`;
-  return function loadEnv() {
+  return function loadEnv(): Env {
     return {
       rootDir,
       env,
@@ -37,3 +37,15 @@ export function loadEnv() {
     };
   };
 }
+
+// Handle flow-types for export so browser export is ignored.
+type Env = {
+  rootDir: string,
+  env: string,
+  prefix: string,
+  assetPath: string,
+  baseAssetPath: string,
+  cdnUrl: string,
+  webpackPublicPath: string,
+};
+declare export default () => Env;


### PR DESCRIPTION
This was broken when we started doing inline typing. Declare the default export to fix existing flow usage.