### PR TITLE
Add <meta charset="utf-8" /> to ensure scripts are interpreted with t…

### DIFF
--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -75,6 +75,7 @@ export default function createSSRPlugin({element, ssrDecider}) {
       '<!doctype html>',
       `<html${safeAttrs}>`,
       `<head>`,
+      `<meta charset="utf-8" />`,
       `<title>${safeTitle}</title>`,
       `${bundleSplittingBootstrap}${safeHead}`,
       `</head>`,


### PR DESCRIPTION
Puppeteer tests could evaluate scripts with incorrect encoding if the document charset is not set to utf-8. This change ensure scripts are interpreted with the correct encoding