### PR TITLE
Add HttpServerToken token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,12 @@ export {
   syncChunkPaths,
 } from './virtual/index.js';
 
-export {RenderToken, ElementToken, SSRDeciderToken, HttpServerToken} from './tokens';
+export {
+  RenderToken,
+  ElementToken,
+  SSRDeciderToken,
+  HttpServerToken,
+} from './tokens';
 export {createPlugin} from './create-plugin';
 export {createToken} from './create-token';
 export {getEnv};

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export {
   syncChunkPaths,
 } from './virtual/index.js';
 
-export {RenderToken, ElementToken, SSRDeciderToken} from './tokens';
+export {RenderToken, ElementToken, SSRDeciderToken, HttpServerToken} from './tokens';
 export {createPlugin} from './create-plugin';
 export {createToken} from './create-token';
 export {getEnv};

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -14,3 +14,4 @@ export const ElementToken = createToken('ElementToken');
 export const SSRDeciderToken: Token<SSRDecider> = createToken(
   'SSRDeciderToken'
 );
+export const HttpServerToken = createToken('HttpServerToken');


### PR DESCRIPTION
Adds a token that represents the node HTTP server instance, used for DI for Websocket support.

I'm not 100% sure if this is the right place to put this token. `fusion-cli` didn't seem like the right place either and it's either here or a plugin that does nothing but expose this token.

I think in the future if we were to build a plugin that encapsulates Websocket logic the token could be moved there.