### PR TITLE
Fix sanitization types

### DIFF
--- a/src/flow/flow-fixtures.js
+++ b/src/flow/flow-fixtures.js
@@ -7,6 +7,7 @@
  */
 
 import {createPlugin, createToken, getEnv} from '../../src/index.js';
+import {html, consumeSanitizedHTML} from '../../src/sanitization';
 import BaseApp from '../../src/base-app';
 
 import type {Context, FusionPlugin, Middleware, Token} from '../types.js';
@@ -145,3 +146,7 @@ async function checkEnv() {
     webpackPublicPath,
   };
 }
+
+/*   - Case: sanitization typing */
+const sanitizedString = html`mystring`;
+consumeSanitizedHTML(sanitizedString);

--- a/src/sanitization.js
+++ b/src/sanitization.js
@@ -46,7 +46,7 @@ if (__NODE__) {
     if (str && str[key]) return consumeSanitizedHTML(str);
     return String(str).replace(/[<>"/\u2028\u2029]/g, replaceForbidden);
   };
-  consumeSanitizedHTML = (h: string): string => {
+  consumeSanitizedHTML = (h: SanitizedHTMLWrapper): string => {
     if (typeof h === 'string') {
       throw new Error(`Unsanitized html. Use html\`${h}\``);
     }
@@ -61,6 +61,7 @@ const unescape = (str: string): string => {
   );
 };
 
+// These types are necessary due to not having an assignment in the __BROWSER__ environment
 const flowHtml = ((html: any): (
   strings: Array<string>,
   ...expressions: Array<string>
@@ -71,7 +72,7 @@ const flowDangerouslySetHTML = ((dangerouslySetHTML: any): (
 ) => Object);
 
 const flowConsumeSanitizedHTML = ((consumeSanitizedHTML: any): (
-  str: string
+  str: SanitizedHTMLWrapper
 ) => string);
 
 const flowEscape = ((escape: any): (str: string) => string);


### PR DESCRIPTION
It seems that this has just been wrong for a long time. Recent fusion-release-verification jobs have been failing with:

![image](https://user-images.githubusercontent.com/122602/43549727-4413adf8-9596-11e8-931f-3303330b8731.png)
