### PR TITLE
Change script order, add fusion-cli peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "ua-parser-js": "^0.7.17",
     "uuid": "^3.2.1"
   },
+  "peerDependencies": {
+    "fusion-cli": "^1.2.2"
+  },
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -22,25 +22,6 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
-  "devDependencies": {
-    "babel-eslint": "^8.2.1",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "create-universal-package": "^3.4.0",
-    "eslint": "^5.0.0",
-    "eslint-config-fusion": "^4.0.0",
-    "eslint-plugin-cup": "^2.0.0",
-    "eslint-plugin-flowtype": "^2.42.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^21.18.0",
-    "eslint-plugin-prettier": "^2.6.0",
-    "eslint-plugin-react": "^7.6.1",
-    "flow-bin": "^0.77.0",
-    "node-fetch": "^2.0.0",
-    "nyc": "^12.0.0",
-    "prettier": "1.14.0",
-    "tape-cup": "^4.7.1",
-    "unitest": "^2.1.1"
-  },
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint . --ignore-path .gitignore",
@@ -60,6 +41,25 @@
     "toposort": "^2.0.1",
     "ua-parser-js": "^0.7.17",
     "uuid": "^3.2.1"
+  },
+  "devDependencies": {
+    "babel-eslint": "^8.2.1",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "create-universal-package": "^3.4.0",
+    "eslint": "^5.0.0",
+    "eslint-config-fusion": "^4.0.0",
+    "eslint-plugin-cup": "^2.0.0",
+    "eslint-plugin-flowtype": "^2.42.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jest": "^21.18.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.6.1",
+    "flow-bin": "^0.77.0",
+    "node-fetch": "^2.0.0",
+    "nyc": "^12.0.0",
+    "prettier": "1.14.0",
+    "tape-cup": "^4.7.1",
+    "unitest": "^2.1.1"
   },
   "engines": {
     "node": ">= 8.9.0"

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -152,11 +152,11 @@ function getChunkScripts(ctx) {
   const preloaded = getUrls(ctx, ctx.preloadChunks).map(({id, url}) => {
     return `<script defer${crossOrigin} src="${url}" data-webpack-preload="${id}"></script>`;
   });
-  return [...sync, ...preloaded].join('');
+  return [...preloaded, ...sync].join('');
 }
 
 function getPreloadHintLinks(ctx) {
-  const chunks = [...ctx.syncChunks, ...ctx.preloadChunks];
+  const chunks = [...ctx.preloadChunks, ...ctx.syncChunks];
   const hints = getUrls(ctx, chunks).map(({url}) => {
     return `<link rel="preload" href="${url}" as="script" />`;
   });


### PR DESCRIPTION
- Moves execution of critical (preloaded) async chunks before "sync" chunks
- Enforces usage of fusion-cli version 1.2.2 or newer (i.e. versions of  fusion-cli using webpack 4)

This will eventually allow for the removal of our custom chunk preloading code (needed in webpack 3 and older)