### PR TITLE
Apply type casting in createToken to avoid $FlowFixMe

### DIFF
--- a/src/create-token.js
+++ b/src/create-token.js
@@ -30,6 +30,5 @@ export class TokenImpl<TResolved> {
 }
 
 export function createToken<TResolvedType>(name: string): Token<TResolvedType> {
-  // $FlowFixMe
-  return new TokenImpl(name);
+  return (((new TokenImpl(name)): any): Token<TResolvedType>);
 }

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -30,5 +30,5 @@ export class TokenImpl<TResolved> {
 }
 
 export function createToken<TResolvedType>(name: string): Token<TResolvedType> {
-  return (((new TokenImpl(name)): any): Token<TResolvedType>);
+  return ((new TokenImpl(name): any): Token<TResolvedType>);
 }


### PR DESCRIPTION
Minor Flow fix to avoid `$FlowFixMe`, given we know the return type for `createToken`.