### PR TITLE
Allow registering an array of plugins

### DIFF
--- a/src/register-plugins.js
+++ b/src/register-plugins.js
@@ -1,0 +1,11 @@
+
+import * as R from 'ramda';
+
+const registerPlugins_ = (compose) => (app) => (plugins) => () =>
+  compose(
+    ...plugins
+  )(app);
+
+export const registerPlugins = (app, plugins) => {
+  return registerPlugins_(R.compose)(app)(plugins);
+}


### PR DESCRIPTION
This allows me to do this:
```js
import {registerPlugins} from 'fusion-core';
import {registerHelmet} from 'fusion-helmet-plugin';

const plugins = [
  registerHelmet(),
  registerApolloClient(),
  registerRouter(),
  registerTheme(),
  registerKoaHelmet(),
  registerI18n(),
  registerFetch()
]

export default registerPlugins(new App(root), plugins);
```

It also encourages plugin libraries to export helper function to register itself. Its interface is

```js
export const registerHelmet = (helmet = HelmetPlugin) => (app) => {
  app.register(helmet);
  return app;
}
```

The benefit is this will hide the complexity and verbosity of `import` and `usage` of `Fusion Token` in main application without sacrifying stability of token system.