### PR TITLE
Move SSR body template into DI system

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -8,8 +8,13 @@
 
 import {createPlugin} from './create-plugin';
 import {createToken, TokenType, TokenImpl} from './create-token';
-import {ElementToken, RenderToken, SSRDeciderToken} from './tokens';
-import {SSRDecider} from './plugins/ssr';
+import {
+  ElementToken,
+  RenderToken,
+  SSRDeciderToken,
+  SSRBodyTemplateToken,
+} from './tokens';
+import {SSRDecider, SSRBodyTemplate} from './plugins/ssr';
 
 import type {aliaser, cleanupFn, FusionPlugin, Token} from './types.js';
 
@@ -22,6 +27,7 @@ class FusionApp {
     el && this.register(ElementToken, el);
     render && this.register(RenderToken, render);
     this.register(SSRDeciderToken, SSRDecider);
+    this.register(SSRBodyTemplateToken, SSRBodyTemplate);
   }
 
   // eslint-disable-next-line

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -8,7 +8,11 @@
 
 import {createPlugin} from '../create-plugin';
 import {escape, consumeSanitizedHTML} from '../sanitization';
-import type {Context, SSRDecider as SSRDeciderService} from '../types.js';
+import type {
+  Context,
+  SSRDecider as SSRDeciderService,
+  SSRBodyTemplate as SSRBodyTemplateService,
+} from '../types.js';
 
 const SSRDecider = createPlugin({
   provides: () => {
@@ -27,12 +31,62 @@ const SSRDecider = createPlugin({
 });
 export {SSRDecider};
 
+const SSRBodyTemplate = createPlugin({
+  provides: () => {
+    return ctx => {
+      const {htmlAttrs, bodyAttrs, title, head, body} = ctx.template;
+      const safeAttrs = Object.keys(htmlAttrs)
+        .map(attrKey => {
+          return ` ${escape(attrKey)}="${escape(htmlAttrs[attrKey])}"`;
+        })
+        .join('');
+
+      const safeBodyAttrs = Object.keys(bodyAttrs)
+        .map(attrKey => {
+          return ` ${escape(attrKey)}="${escape(bodyAttrs[attrKey])}"`;
+        })
+        .join('');
+
+      const safeTitle = escape(title);
+      // $FlowFixMe
+      const safeHead = head.map(consumeSanitizedHTML).join('');
+      // $FlowFixMe
+      const safeBody = body.map(consumeSanitizedHTML).join('');
+
+      const preloadHintLinks = getPreloadHintLinks(ctx);
+      const coreGlobals = getCoreGlobals(ctx);
+      const chunkScripts = getChunkScripts(ctx);
+      const bundleSplittingBootstrap = [
+        preloadHintLinks,
+        coreGlobals,
+        chunkScripts,
+      ].join('');
+
+      return [
+        '<!doctype html>',
+        `<html${safeAttrs}>`,
+        `<head>`,
+        `<meta charset="utf-8" />`,
+        `<title>${safeTitle}</title>`,
+        `${bundleSplittingBootstrap}${safeHead}`,
+        `</head>`,
+        `<body${safeBodyAttrs}>${ctx.rendered}${safeBody}</body>`,
+        '</html>',
+      ].join('');
+    };
+  },
+});
+
+export {SSRBodyTemplate};
+
 export default function createSSRPlugin({
   element,
   ssrDecider,
+  ssrBodyTemplate,
 }: {
   element: any,
   ssrDecider: SSRDeciderService,
+  ssrBodyTemplate: SSRBodyTemplateService,
 }) {
   return async function ssrPlugin(ctx: Context, next: () => Promise<void>) {
     if (!ssrDecider(ctx)) return next();
@@ -57,45 +111,7 @@ export default function createSSRPlugin({
       return;
     }
 
-    const {htmlAttrs, bodyAttrs, title, head, body} = ctx.template;
-    const safeAttrs = Object.keys(htmlAttrs)
-      .map(attrKey => {
-        return ` ${escape(attrKey)}="${escape(htmlAttrs[attrKey])}"`;
-      })
-      .join('');
-
-    const safeBodyAttrs = Object.keys(bodyAttrs)
-      .map(attrKey => {
-        return ` ${escape(attrKey)}="${escape(bodyAttrs[attrKey])}"`;
-      })
-      .join('');
-
-    const safeTitle = escape(title);
-    // $FlowFixMe
-    const safeHead = head.map(consumeSanitizedHTML).join('');
-    // $FlowFixMe
-    const safeBody = body.map(consumeSanitizedHTML).join('');
-
-    const preloadHintLinks = getPreloadHintLinks(ctx);
-    const coreGlobals = getCoreGlobals(ctx);
-    const chunkScripts = getChunkScripts(ctx);
-    const bundleSplittingBootstrap = [
-      preloadHintLinks,
-      coreGlobals,
-      chunkScripts,
-    ].join('');
-
-    ctx.body = [
-      '<!doctype html>',
-      `<html${safeAttrs}>`,
-      `<head>`,
-      `<meta charset="utf-8" />`,
-      `<title>${safeTitle}</title>`,
-      `${bundleSplittingBootstrap}${safeHead}`,
-      `</head>`,
-      `<body${safeBodyAttrs}>${ctx.rendered}${safeBody}</body>`,
-      '</html>',
-    ].join('');
+    ctx.body = ssrBodyTemplate(ctx);
   };
 }
 

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -10,7 +10,12 @@ import {compose} from './compose.js';
 import Timing, {TimingToken} from './plugins/timing';
 import BaseApp from './base-app';
 import serverRenderer from './plugins/server-renderer';
-import {RenderToken, ElementToken, SSRDeciderToken} from './tokens';
+import {
+  RenderToken,
+  ElementToken,
+  SSRDeciderToken,
+  SSRBodyTemplateToken,
+} from './tokens';
 import ssrPlugin from './plugins/ssr';
 import contextMiddleware from './plugins/server-context.js';
 
@@ -25,7 +30,11 @@ export default function(): typeof BaseApp {
       this.middleware(contextMiddleware);
       this.register(TimingToken, Timing);
       this.middleware(
-        {element: ElementToken, ssrDecider: SSRDeciderToken},
+        {
+          element: ElementToken,
+          ssrDecider: SSRDeciderToken,
+          ssrBodyTemplate: SSRBodyTemplateToken,
+        },
         ssrPlugin
       );
     }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -7,7 +7,7 @@
  */
 
 import {createToken} from './create-token';
-import type {SSRDecider, Token} from './types.js';
+import type {SSRDecider, SSRBodyTemplate, Token} from './types.js';
 
 export const RenderToken = createToken('RenderToken');
 export const ElementToken = createToken('ElementToken');
@@ -15,3 +15,6 @@ export const SSRDeciderToken: Token<SSRDecider> = createToken(
   'SSRDeciderToken'
 );
 export const HttpServerToken = createToken('HttpServerToken');
+export const SSRBodyTemplateToken: Token<SSRBodyTemplate> = createToken(
+  'SSRBodyTemplateToken'
+);

--- a/src/types.js
+++ b/src/types.js
@@ -59,3 +59,5 @@ export type aliaser<TToken> = {
 };
 
 export type cleanupFn = (thing: any) => Promise<void>;
+
+export type SSRBodyTemplate = Context => $PropertyType<Context, 'body'>;


### PR DESCRIPTION
The SSR body template is tightly coupled with the build system (fusion-cli) but this code lives in fusion-core. Moving the SSR body template into the DI system will allow fusion-cli to register its own SSR body template (ensuring it is always the correct code). This change also makes fusion-core and fusion-cli properly decoupled as presumably an alternative build system could register its own template as well.