### PR TITLE
Change server context shape, make SSRBodyTemplate optional

### DIFF
--- a/src/__tests__/app.node.js
+++ b/src/__tests__/app.node.js
@@ -10,8 +10,6 @@ import test from 'tape-cup';
 import App from '../index';
 import {compose} from '../compose.js';
 
-import type {Context} from '../types.js';
-
 test('context composition', async t => {
   const element = 'hello';
   const render = el => `<h1>${el}</h1>`;
@@ -19,17 +17,10 @@ test('context composition', async t => {
     ctx.element = ctx.element.toUpperCase();
     return next();
   };
-  const chunkUrlMap = new Map();
-  const chunkIdZero = new Map();
-  chunkIdZero.set('es5', 'es5-file.js');
-  chunkUrlMap.set(0, chunkIdZero);
+
   const context = {
     headers: {accept: 'text/html'},
     path: '/',
-    syncChunks: [0],
-    preloadChunks: [],
-    chunkUrlMap,
-    webpackPublicPath: '/',
     element: null,
     rendered: null,
     render: null,
@@ -48,45 +39,6 @@ test('context composition', async t => {
     t.equals(typeof context.rendered, 'string', 'renders');
     // $FlowFixMe
     t.ok(context.rendered.includes('<h1>HELLO</h1>'), 'has expected html');
-  } catch (e) {
-    t.ifError(e, 'something went wrong');
-  }
-  t.end();
-});
-
-test('context composition with a cdn', async t => {
-  const element = 'hello';
-  const render = el => `<h1>${el}</h1>`;
-  const wrap = () => (ctx: Context, next: () => Promise<void>) => {
-    ctx.element = ctx.element.toUpperCase();
-    return next();
-  };
-  const chunkUrlMap = new Map();
-  const chunkIdZero = new Map();
-  chunkIdZero.set('es5', 'es5-file.js');
-  chunkUrlMap.set(0, chunkIdZero);
-  const context = {
-    headers: {accept: 'text/html'},
-    path: '/',
-    syncChunks: [0],
-    preloadChunks: [],
-    chunkUrlMap,
-    webpackPublicPath: 'https://something.com/lol',
-    element: null,
-    rendered: null,
-    render: null,
-    type: null,
-    body: null,
-  };
-
-  const app = new App(element, render);
-  app.middleware(wrap());
-  app.resolve();
-  const middleware = compose(app.plugins);
-  try {
-    await middleware(((context: any): Context), () => Promise.resolve());
-    // $FlowFixMe
-    t.ok(context.body.includes('https://something.com/lol/es5-file.js'));
   } catch (e) {
     t.ifError(e, 'something went wrong');
   }

--- a/src/__tests__/env.node.js
+++ b/src/__tests__/env.node.js
@@ -12,58 +12,34 @@ import {loadEnv} from '../get-env.js';
 tape('loadEnv defaults', t => {
   const env = loadEnv()();
   t.deepEqual(env, {
-    rootDir: '.',
-    env: 'development',
-    prefix: '',
-    assetPath: '/_static',
-    baseAssetPath: '/_static',
-    cdnUrl: '',
-    webpackPublicPath: '/_static',
+    prefix: void 0,
+    cdnUrl: void 0,
   });
   t.end();
 });
 
 tape('loadEnv overrides', t => {
-  process.env.ROOT_DIR = 'test_root_dir';
-  process.env.NODE_ENV = 'production';
-  process.env.ROUTE_PREFIX = 'test_route_prefix';
-  process.env.FRAMEWORK_STATIC_ASSET_PATH = '/test_framework';
-  process.env.CDN_URL = 'test_cdn_url';
+  process.env.ROUTE_PREFIX = '/test_route_prefix';
+  process.env.CDN_URL = 'https://cdn.com';
 
   const env = loadEnv()();
   t.deepEqual(env, {
-    rootDir: 'test_root_dir',
-    env: 'production',
-    prefix: 'test_route_prefix',
-    assetPath: 'test_route_prefix/test_framework',
-    baseAssetPath: '/test_framework',
-    cdnUrl: 'test_cdn_url',
-    webpackPublicPath: 'test_cdn_url',
+    prefix: '/test_route_prefix',
+    cdnUrl: 'https://cdn.com',
   });
 
-  process.env.ROOT_DIR = '';
-  process.env.NODE_ENV = '';
-  process.env.ROUTE_PREFIX = '';
-  process.env.FRAMEWORK_STATIC_ASSET_PATH = '';
-  process.env.CDN_URL = '';
+  delete process.env.ROUTE_PREFIX;
+  delete process.env.CDN_URL;
   t.end();
 });
 
 tape('loadEnv validation', t => {
-  process.env.NODE_ENV = 'LOL';
-  t.throws(loadEnv, /Invalid NODE_ENV loaded/);
-  process.env.NODE_ENV = '';
-
   process.env.ROUTE_PREFIX = 'test/';
   t.throws(loadEnv, /ROUTE_PREFIX must not end with /);
-  process.env.ROUTE_PREFIX = '';
+  delete process.env.ROUTE_PREFIX;
 
-  process.env.FRAMEWORK_STATIC_ASSET_PATH = 'test/';
-  t.throws(loadEnv, /FRAMEWORK_STATIC_ASSET_PATH must not end with /);
-  process.env.FRAMEWORK_STATIC_ASSET_PATH = '';
-
-  process.env.CDN_URL = 'test/';
+  process.env.CDN_URL = 'https://cdn.com/test/';
   t.throws(loadEnv, /CDN_URL must not end with /);
-  process.env.CDN_URL = '';
+  delete process.env.CDN_URL;
   t.end();
 });

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -8,15 +8,10 @@
 
 import {createPlugin} from './create-plugin';
 import {createToken, TokenType, TokenImpl} from './create-token';
-import {
-  ElementToken,
-  RenderToken,
-  SSRDeciderToken,
-  SSRBodyTemplateToken,
-} from './tokens';
-import {SSRDecider, SSRBodyTemplate} from './plugins/ssr';
+import {ElementToken, RenderToken, SSRDeciderToken} from './tokens';
 
 import type {aliaser, cleanupFn, FusionPlugin, Token} from './types.js';
+import {SSRDecider} from './plugins/ssr';
 
 class FusionApp {
   constructor(el: Element | string, render: *) {
@@ -27,7 +22,6 @@ class FusionApp {
     el && this.register(ElementToken, el);
     render && this.register(RenderToken, render);
     this.register(SSRDeciderToken, SSRDecider);
-    this.register(SSRBodyTemplateToken, SSRBodyTemplate);
   }
 
   // eslint-disable-next-line

--- a/src/flow/flow-fixtures.js
+++ b/src/flow/flow-fixtures.js
@@ -127,23 +127,10 @@ async function cleanup() {
 
 /*   - Case: getEnv typing */
 async function checkEnv() {
-  const {
-    rootDir,
-    env,
-    prefix,
-    assetPath,
-    baseAssetPath,
-    cdnUrl,
-    webpackPublicPath,
-  } = getEnv();
+  const {prefix, cdnUrl} = getEnv();
   return {
-    rootDir,
-    env,
     prefix,
-    assetPath,
-    baseAssetPath,
     cdnUrl,
-    webpackPublicPath,
   };
 }
 

--- a/src/plugins/server-context.js
+++ b/src/plugins/server-context.js
@@ -15,24 +15,18 @@ import type {Context} from '../types.js';
 const envVars = getEnv();
 
 export default function middleware(ctx: Context, next: () => Promise<void>) {
-  // env vars
-  ctx.rootDir = envVars.rootDir;
-  ctx.env = envVars.env;
+  let assetBase = '/_static/';
+  if (envVars.cdnUrl) {
+    assetBase = envVars.cdnUrl;
+  } else if (envVars.prefix) {
+    assetBase = envVars.prefix + assetBase;
+  }
+
   ctx.prefix = envVars.prefix;
-  ctx.assetPath = envVars.assetPath;
-  ctx.cdnUrl = envVars.cdnUrl;
-
-  // webpack-related things
-  ctx.preloadChunks = [];
-  ctx.webpackPublicPath =
-    ctx.webpackPublicPath || envVars.cdnUrl || envVars.assetPath;
-
-  // these are set by fusion-cli, however since fusion-cli plugins are not added when
-  // running simulation tests, it is good to default them here
-  ctx.syncChunks = ctx.syncChunks || [];
-  ctx.chunkUrlMap = ctx.chunkUrlMap || new Map();
-
-  // fusion-specific things
+  ctx.assetBase = assetBase;
+  ctx.assets = new Set();
+  ctx.criticalAssets = new Set();
+  ctx.chunkAssetIndex = new Map();
   ctx.nonce = uuidv4();
   ctx.useragent = new UAParser(ctx.headers['user-agent']).getResult();
   ctx.element = null;

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -7,7 +7,6 @@
  */
 
 import {createPlugin} from '../create-plugin';
-import {escape, consumeSanitizedHTML} from '../sanitization';
 import type {
   Context,
   SSRDecider as SSRDeciderService,
@@ -17,9 +16,7 @@ import type {
 const SSRDecider = createPlugin({
   provides: () => {
     return ctx => {
-      // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
-      // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
-      if (ctx.path.match(/\.(js|gif|jpg|png|pdf|json)$/)) return false;
+      if (ctx.path.startsWith(ctx.assetBase)) return false;
       // The Accept header is a good proxy for whether SSR should happen
       // Requesting an HTML page via the browser url bar generates a request with `text/html` in its Accept headers
       // XHR/fetch requests do not have `text/html` in the Accept headers
@@ -31,54 +28,6 @@ const SSRDecider = createPlugin({
 });
 export {SSRDecider};
 
-const SSRBodyTemplate = createPlugin({
-  provides: () => {
-    return ctx => {
-      const {htmlAttrs, bodyAttrs, title, head, body} = ctx.template;
-      const safeAttrs = Object.keys(htmlAttrs)
-        .map(attrKey => {
-          return ` ${escape(attrKey)}="${escape(htmlAttrs[attrKey])}"`;
-        })
-        .join('');
-
-      const safeBodyAttrs = Object.keys(bodyAttrs)
-        .map(attrKey => {
-          return ` ${escape(attrKey)}="${escape(bodyAttrs[attrKey])}"`;
-        })
-        .join('');
-
-      const safeTitle = escape(title);
-      // $FlowFixMe
-      const safeHead = head.map(consumeSanitizedHTML).join('');
-      // $FlowFixMe
-      const safeBody = body.map(consumeSanitizedHTML).join('');
-
-      const preloadHintLinks = getPreloadHintLinks(ctx);
-      const coreGlobals = getCoreGlobals(ctx);
-      const chunkScripts = getChunkScripts(ctx);
-      const bundleSplittingBootstrap = [
-        preloadHintLinks,
-        coreGlobals,
-        chunkScripts,
-      ].join('');
-
-      return [
-        '<!doctype html>',
-        `<html${safeAttrs}>`,
-        `<head>`,
-        `<meta charset="utf-8" />`,
-        `<title>${safeTitle}</title>`,
-        `${bundleSplittingBootstrap}${safeHead}`,
-        `</head>`,
-        `<body${safeBodyAttrs}>${ctx.rendered}${safeBody}</body>`,
-        '</html>',
-      ].join('');
-    };
-  },
-});
-
-export {SSRBodyTemplate};
-
 export default function createSSRPlugin({
   element,
   ssrDecider,
@@ -86,7 +35,7 @@ export default function createSSRPlugin({
 }: {
   element: any,
   ssrDecider: SSRDeciderService,
-  ssrBodyTemplate: SSRBodyTemplateService,
+  ssrBodyTemplate?: SSRBodyTemplateService,
 }) {
   return async function ssrPlugin(ctx: Context, next: () => Promise<void>) {
     if (!ssrDecider(ctx)) return next();
@@ -111,60 +60,8 @@ export default function createSSRPlugin({
       return;
     }
 
-    ctx.body = ssrBodyTemplate(ctx);
-  };
-}
-
-function getCoreGlobals(ctx) {
-  const {webpackPublicPath, nonce} = ctx;
-
-  return [
-    `<script nonce="${nonce}">`,
-    `window.performance && window.performance.mark && window.performance.mark('firstRenderStart');`,
-    `__ROUTE_PREFIX__ = ${JSON.stringify(ctx.prefix)};`, // consumed by ./client
-    `__WEBPACK_PUBLIC_PATH__ = ${JSON.stringify(webpackPublicPath)};`, // consumed by fusion-clientries/client-entry
-    `</script>`,
-  ].join('');
-}
-
-function getUrls({chunkUrlMap, webpackPublicPath}, chunks) {
-  return [...new Set(chunks)].map(id => {
-    let url = chunkUrlMap.get(id).get('es5');
-    if (webpackPublicPath.endsWith('/')) {
-      url = webpackPublicPath + url;
-    } else {
-      url = webpackPublicPath + '/' + url;
+    if (ssrBodyTemplate) {
+      ctx.body = ssrBodyTemplate(ctx);
     }
-    return {id, url};
-  });
-}
-
-function getChunkScripts(ctx) {
-  const webpackPublicPath = ctx.webpackPublicPath || '';
-  // cross origin is needed to get meaningful errors in window.onerror
-  const crossOrigin = webpackPublicPath.startsWith('https://')
-    ? ' crossorigin="anonymous"'
-    : '';
-  const sync = getUrls(ctx, ctx.syncChunks).map(({url}) => {
-    return `<script nonce="${
-      ctx.nonce
-    }" defer${crossOrigin} src="${url}"></script>`;
-  });
-  const preloaded = getUrls(
-    ctx,
-    ctx.preloadChunks.filter(item => !ctx.syncChunks.includes(item))
-  ).map(({id, url}) => {
-    return `<script nonce="${
-      ctx.nonce
-    }" defer${crossOrigin} src="${url}"></script>`;
-  });
-  return [...preloaded, ...sync].join('');
-}
-
-function getPreloadHintLinks(ctx) {
-  const chunks = [...ctx.preloadChunks, ...ctx.syncChunks];
-  const hints = getUrls(ctx, chunks).map(({url}) => {
-    return `<link rel="preload" href="${url}" as="script" />`;
-  });
-  return hints.join('');
+  };
 }

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -33,7 +33,7 @@ export default function(): typeof BaseApp {
         {
           element: ElementToken,
           ssrDecider: SSRDeciderToken,
-          ssrBodyTemplate: SSRBodyTemplateToken,
+          ssrBodyTemplate: SSRBodyTemplateToken.optional,
         },
         ssrPlugin
       );


### PR DESCRIPTION
This PR further decouples fusion-core from fusion-cli.

**Changes**
- Remove default SSRBodyTemplate, make it optional. For simulation tests, assertions should just use `ctx.rendered`, rather than assuming how `ctx.body` gets constructed.
- Change default SSRDecider to check path prefix against `ctx.assetBase` rather than check extensions.
- Change server context shape:

```diff
prefix
cdnUrl
nonce
useragent
element
- rootDir
- env
- assetPath
- preloadChunks
- webpackPublicPath
- syncChunks
- chunkUrlMap
+ assets
+ assetBase
+ criticalAssets
+ chunkAssetIndex
```