### PR TITLE
Refactor extraneous registration logic to support plugins that are re-registered

### DIFF
--- a/src/__tests__/dependency-resolution.js
+++ b/src/__tests__/dependency-resolution.js
@@ -535,6 +535,22 @@ tape('Extraneous dependencies', t => {
   t.end();
 });
 
+tape('Extraneous dependencies after re-registering', t => {
+  const app = new App('el', el => el);
+  const TokenA = createToken('A');
+  const TokenB = createToken('B');
+  app.register(
+    TokenA,
+    createPlugin({
+      deps: {b: TokenB},
+    })
+  );
+  app.register(TokenB, 'test');
+  app.register(TokenA, createPlugin({}));
+  t.doesNotThrow(() => app.resolve());
+  t.end();
+});
+
 tape('Missing token errors reasonably', t => {
   const app = new App('el', el => el);
   // $FlowFixMe

--- a/src/__tests__/enhance.js
+++ b/src/__tests__/enhance.js
@@ -68,6 +68,7 @@ tape('enhancement with a plugin with deps', t => {
 
   const DepAToken: Token<string> = createToken('DepA');
   const DepBToken: Token<string> = createToken('DepB');
+  const DepCToken: Token<string> = createToken('DepC');
 
   const DepA = 'test-dep-a';
   const DepB: FusionPlugin<{a: Token<string>}, string> = createPlugin({
@@ -89,15 +90,20 @@ tape('enhancement with a plugin with deps', t => {
   });
   const BaseFnEnhancer = (
     fn: FnType
-  ): FusionPlugin<{a: Token<string>, b: Token<string>}, FnType> => {
+  ): FusionPlugin<
+    {a: Token<string>, b: Token<string>, c: Token<string>},
+    FnType
+  > => {
     return createPlugin({
       deps: {
         a: DepAToken,
         b: DepBToken,
+        c: DepCToken,
       },
-      provides: ({a, b}) => {
+      provides: ({a, b, c}) => {
         t.equal(a, 'test-dep-a');
         t.equal(b, 'test-dep-b');
+        t.equal(c, 'test-dep-c');
         return arg => {
           return fn(arg) + ' enhanced';
         };
@@ -106,6 +112,7 @@ tape('enhancement with a plugin with deps', t => {
   };
   app.register(DepAToken, DepA);
   app.register(DepBToken, DepB);
+  app.register(DepCToken, 'test-dep-c');
   app.register(FnToken, BaseFn);
   app.enhance(FnToken, BaseFnEnhancer);
   app.middleware({fn: FnToken}, ({fn}) => {


### PR DESCRIPTION
This PR makes a change to allow extraneous values to be registered in the case where they were depended on at some point during the application setup process. This is common during testing when you might register a mock that doesn't share all the same dependencies as the real implementation. This also could be useful when sharing code.