### PR TITLE
Deprecate old context properties and env vars

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -8,13 +8,8 @@
 
 import {createPlugin} from './create-plugin';
 import {createToken, TokenType, TokenImpl} from './create-token';
-import {
-  ElementToken,
-  RenderToken,
-  SSRDeciderToken,
-  SSRBodyTemplateToken,
-} from './tokens';
-import {SSRDecider, SSRBodyTemplate} from './plugins/ssr';
+import {ElementToken, RenderToken, SSRDeciderToken} from './tokens';
+import {SSRDecider} from './plugins/ssr';
 
 import type {aliaser, cleanupFn, FusionPlugin, Token} from './types.js';
 
@@ -27,7 +22,6 @@ class FusionApp {
     el && this.register(ElementToken, el);
     render && this.register(RenderToken, render);
     this.register(SSRDeciderToken, SSRDecider);
-    this.register(SSRBodyTemplateToken, SSRBodyTemplate);
   }
 
   // eslint-disable-next-line

--- a/src/get-env.js
+++ b/src/get-env.js
@@ -15,6 +15,8 @@ function load(key, value) {
 }
 
 export function loadEnv() {
+  console.warn('Warning: getEnv from fusion-core is deprecated.'); // eslint-disable-line no-console
+
   const rootDir = load('ROOT_DIR', '.');
   const env = load('NODE_ENV', 'development');
   if (!(env === 'development' || env === 'production' || env === 'test')) {

--- a/src/plugins/server-context.js
+++ b/src/plugins/server-context.js
@@ -11,28 +11,93 @@ import UAParser from 'ua-parser-js';
 import getEnv from '../get-env.js';
 
 import type {Context} from '../types.js';
+// Flow workaround: https://github.com/facebook/flow/issues/285#issuecomment-382044301
+const {defineProperty} = Object;
 
-const envVars = getEnv();
+let envVars = null;
+const lazyEnv = new Proxy(
+  {},
+  {
+    get(_, prop) {
+      if (!envVars) {
+        envVars = getEnv();
+      }
+      return envVars[prop];
+    },
+  }
+);
 
 export default function middleware(ctx: Context, next: () => Promise<void>) {
-  // env vars
-  ctx.rootDir = envVars.rootDir;
-  ctx.env = envVars.env;
-  ctx.prefix = envVars.prefix;
-  ctx.assetPath = envVars.assetPath;
-  ctx.cdnUrl = envVars.cdnUrl;
+  let deprecated = (property, value, details) => {
+    defineProperty(ctx, property, {
+      enumerable: true,
+      configurable: true,
+      set(newValue) {
+        value = newValue;
+      },
+      get() {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Warning: ctx.${property} is deprecated and may be incorrect or inaccurate. ctx.${property} should no longer be used.`
+        );
+        if (details) {
+          // eslint-disable-next-line no-console
+          console.warn(details);
+        }
+        return value;
+      },
+    });
+  };
 
-  // webpack-related things
-  ctx.preloadChunks = [];
-  ctx.webpackPublicPath =
-    ctx.webpackPublicPath || envVars.cdnUrl || envVars.assetPath;
+  // env vars (deprecated)
+  deprecated('rootDir', lazyEnv.rootDir);
+  deprecated('env', lazyEnv.env);
+  deprecated(
+    'prefix',
+    lazyEnv.prefix,
+    [
+      'To retrieve the route prefix, depend on the RoutePrefixToken instead.',
+      'You may be able to resolve this warning by upgrading fusion-plugin-react-router, and/or fusion-plugin-error-handling.',
+    ].join(' ')
+  );
+  deprecated('assetPath', lazyEnv.assetPath);
+  deprecated('cdnUrl', lazyEnv.cdnUrl);
+
+  // webpack-related things (deprecated)
+  deprecated(
+    'preloadChunks',
+    [],
+    'You may be able to resolve this warning by upgrading fusion-react, fusion-react-async, and/or fusion-cli.'
+  );
+  deprecated(
+    'webpackPublicPath',
+    ctx.webpackPublicPath || lazyEnv.cdnUrl || lazyEnv.assetPath,
+    [
+      'Use __webpack_public_path__ instead.',
+      'You may be able to resolve this warning by upgrading fusion-cli.',
+    ].join(' ')
+  );
 
   // these are set by fusion-cli, however since fusion-cli plugins are not added when
   // running simulation tests, it is good to default them here
-  ctx.syncChunks = ctx.syncChunks || [];
-  ctx.chunkUrlMap = ctx.chunkUrlMap || new Map();
+  // (deprecated)
+  deprecated(
+    'syncChunks',
+    ctx.syncChunks || [],
+    [
+      'To retrieve the route prefix, depend on the RoutePrefixToken instead.',
+      'You may be able to resolve this warning by upgrading fusion-plugin-i18n and/or fusion-cli.',
+    ].join(' ')
+  );
+  deprecated(
+    'chunkUrlMap',
+    ctx.chunkUrlMap || new Map(),
+    [
+      'To retrieve the route prefix, depend on the RoutePrefixToken instead.',
+      'You may be able to resolve this warning by upgrading fusion-cli.',
+    ].join(' ')
+  );
 
-  // fusion-specific things
   ctx.nonce = uuidv4();
   ctx.useragent = new UAParser(ctx.headers['user-agent']).getResult();
   ctx.element = null;

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -33,7 +33,7 @@ export default function(): typeof BaseApp {
         {
           element: ElementToken,
           ssrDecider: SSRDeciderToken,
-          ssrBodyTemplate: SSRBodyTemplateToken,
+          ssrBodyTemplate: SSRBodyTemplateToken.optional,
         },
         ssrPlugin
       );


### PR DESCRIPTION
- fusion-cli should provide the `SSRBodyTemplate`
- Simulation tests should assert against `ctx.rendered` and `ctx.template` instead of `ctx.body`, because the final HTML depends on the SSRBodyTemplate which comes from fusion-cli and depends on build-time things.