### PR TITLE
Make SSRBodyTemplate optional, export RoutePrefixToken and CriticalChunkIdsToken

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -8,13 +8,8 @@
 
 import {createPlugin} from './create-plugin';
 import {createToken, TokenType, TokenImpl} from './create-token';
-import {
-  ElementToken,
-  RenderToken,
-  SSRDeciderToken,
-  SSRBodyTemplateToken,
-} from './tokens';
-import {SSRDecider, SSRBodyTemplate} from './plugins/ssr';
+import {ElementToken, RenderToken, SSRDeciderToken} from './tokens';
+import {SSRDecider} from './plugins/ssr';
 
 import type {aliaser, cleanupFn, FusionPlugin, Token} from './types.js';
 
@@ -27,7 +22,6 @@ class FusionApp {
     el && this.register(ElementToken, el);
     render && this.register(RenderToken, render);
     this.register(SSRDeciderToken, SSRDecider);
-    this.register(SSRBodyTemplateToken, SSRBodyTemplate);
   }
 
   // eslint-disable-next-line

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,13 @@
  *
  * @flow
  */
-import type {Context, FusionPlugin, Middleware, Token} from './types.js';
+import type {
+  Context,
+  FusionPlugin,
+  Middleware,
+  Token,
+  SSRBodyTemplate,
+} from './types.js';
 
 import BaseApp from './base-app';
 import serverApp from './server-app';
@@ -40,6 +46,8 @@ export {
   SSRDeciderToken,
   HttpServerToken,
   SSRBodyTemplateToken,
+  RoutePrefixToken,
+  CriticalChunkIdsToken,
 } from './tokens';
 export {createPlugin} from './create-plugin';
 export {createToken} from './create-token';
@@ -47,4 +55,11 @@ export {getEnv};
 
 type FusionApp = typeof BaseApp;
 declare export default typeof BaseApp;
-export type {Context, FusionApp, FusionPlugin, Middleware, Token};
+export type {
+  Context,
+  FusionApp,
+  FusionPlugin,
+  Middleware,
+  Token,
+  SSRBodyTemplate,
+};

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -33,7 +33,7 @@ export default function(): typeof BaseApp {
         {
           element: ElementToken,
           ssrDecider: SSRDeciderToken,
-          ssrBodyTemplate: SSRBodyTemplateToken,
+          ssrBodyTemplate: SSRBodyTemplateToken.optional,
         },
         ssrPlugin
       );

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -7,7 +7,7 @@
  */
 
 import {createToken} from './create-token';
-import type {SSRDecider, SSRBodyTemplate, Token} from './types.js';
+import type {SSRDecider, SSRBodyTemplate, Token, Context} from './types.js';
 
 export const RenderToken = createToken('RenderToken');
 export const ElementToken = createToken('ElementToken');
@@ -18,3 +18,14 @@ export const HttpServerToken = createToken('HttpServerToken');
 export const SSRBodyTemplateToken: Token<SSRBodyTemplate> = createToken(
   'SSRBodyTemplateToken'
 );
+export const RoutePrefixToken: Token<string> = createToken('RoutePrefixToken');
+
+export type CriticalChunkIds = Set<number>;
+
+export type CriticalChunkIdsService = {
+  from(ctx: Context): CriticalChunkIds,
+};
+
+export const CriticalChunkIdsToken: Token<
+  CriticalChunkIdsService
+> = createToken('CriticalChunkIdsToken');


### PR DESCRIPTION
- Make `SSRBodyTemplate` optional by using old built-in template if not registered.
- Export two new tokens:
  -  `CriticalChunkIdsToken` (for use in future versions of fusion-cli, fusion-react, fusion-plugin-i18n, etc.)
  -  `RoutePrefixToken` (for use in future versions of fusion-cli, fusion-plugin-react-router, etc.)
  - These tokens will eventually be used instead of the corresponding context properties, which will be deprecated in a future version of fusion-core.