### PR TITLE
Add CSP nonce to preload link tags

### DIFF
--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -162,7 +162,9 @@ function getChunkScripts(ctx) {
 function getPreloadHintLinks(ctx) {
   const chunks = [...ctx.preloadChunks, ...ctx.syncChunks];
   const hints = getUrls(ctx, chunks).map(({url}) => {
-    return `<link rel="preload" href="${url}" nonce="${ctx.nonce}" as="script" />`;
+    return `<link rel="preload" href="${url}" nonce="${
+      ctx.nonce
+    }" as="script" />`;
   });
   return hints.join('');
 }

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -162,7 +162,7 @@ function getChunkScripts(ctx) {
 function getPreloadHintLinks(ctx) {
   const chunks = [...ctx.preloadChunks, ...ctx.syncChunks];
   const hints = getUrls(ctx, chunks).map(({url}) => {
-    return `<link rel="preload" href="${url}" as="script" />`;
+    return `<link rel="preload" href="${url}" nonce="${ctx.nonce}" as="script" />`;
   });
   return hints.join('');
 }


### PR DESCRIPTION
This fix is needed for preload tags to work when using a Strict CSP policy.