### PR TITLE
Release v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-core",
   "description": "A generic entry point class for FusionJS applications that is used by the FusionJS runtime.",
-  "version": "1.7.0-2",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": "fusionjs/fusion-core",
   "files": [


### PR DESCRIPTION
- Fix double fetching resulting from preload hint cache miss if using CDN ([#314](https://github.com/fusionjs/fusion-core/pull/314))
- Add CSP nonce to preload link tags ([#313](https://github.com/fusionjs/fusion-core/pull/313))
- Make SSRBodyTemplate optional, export RoutePrefixToken and CriticalChunkIdsToken ([#309](https://github.com/fusionjs/fusion-core/pull/309))
- Expose resolved services as a private API ([#290](https://github.com/fusionjs/fusion-core/pull/290))
- Refactor extraneous registration logic to support plugins that are re-registered ([#297](https://github.com/fusionjs/fusion-core/pull/297))