### PR TITLE
Make missing token error more actionable

### DIFF
--- a/src/__tests__/enhance.js
+++ b/src/__tests__/enhance.js
@@ -164,7 +164,7 @@ tape('enhancement with a plugin with missing deps', t => {
   });
   t.throws(
     () => app.resolve(),
-    /Could not resolve token: "DepA", which is required by plugins registered with tokens: "EnhancerOf<FnType>"./
+    /This token is required by plugins registered with tokens: "EnhancerOf<FnType>"/
   );
   t.end();
 });

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -202,7 +202,7 @@ class FusionApp {
           const base =
             'A plugin depends on a token, but the token was not registered';
           const downstreams =
-            'Dependents: ' +
+            'This token is required by plugins registered with tokens: ' +
             dependentTokens.map(token => `"${token}"`).join(', ');
           const meta = `Required token: ${
             token ? token.name : ''

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -219,8 +219,7 @@ class FusionApp {
             'Ensure that `yarn list [the-plugin]` results in one version, ' +
             'and use a yarn resolution or merge package version in your lock file to consolidate versions.\n\n';
           throw new Error(
-            `${base}\n\n${meta}\n${dependents}\n\n${suggestions &&
-              clue + suggestions + help}`
+            `${base}\n\n${meta}\n\n${suggestions && clue + suggestions + help}`
           );
         }
       }

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -18,11 +18,13 @@ export class TokenImpl<TResolved> {
   ref: mixed;
   type: $Values<typeof TokenType>;
   optional: ?TokenImpl<TResolved>;
+  stack: string;
 
   constructor(name: string, ref: mixed) {
     this.name = name;
     this.ref = ref || new Ref();
     this.type = ref ? TokenType.Optional : TokenType.Required;
+    this.stack = new Error().stack;
     if (!ref) {
       this.optional = new TokenImpl(name, this.ref);
     }

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,7 @@ import type {Context as KoaContext} from 'koa';
 export type Token<T> = {
   (): T,
   optional: () => void | T,
+  stack: string,
 };
 
 type ExtendedKoaContext = KoaContext & {memoized: Map<Object, mixed>};


### PR DESCRIPTION
TL;DR: People have been running into an issue where having multiple versions of a same plugin would cause the DI system to throw errors about missing dependencies. The error was cryptic and difficult to troubleshoot.

This PR  exposes stack information about the missing token as well as potential problematic duplicated tokens, and it offers actionable suggestions to fix the issue.

I labeled this PR w/ the feature flag because this diff adds a `stack` field to `Token`

```
// Before
Error: Could not resolve token: "A", which is required by plugins registered with tokens: "UnnamedPlugin". Did you forget to register a value for "A"?
    at resolveToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/src/base-app.js:202:15)
    at resolvePlugin (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:544:31)
    at resolveToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:560:20)
    at App.resolve (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:590:7)
    at App.resolve (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:895:20)
    at App.callback (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:899:12)
    at reload (/Users/lhorie/Documents/aaa/node_modules/fusion-cli/entries/server-entry.js:90:1)
    at 
    at process._tickCallback (internal/process/next_tick.js:189:7)
    at evalScript (bootstrap_node.js:482:13)

// After
Error: A plugin depends on a token, but the token was not registered

Required token: A
This token is required by plugins registered with tokens: "Foo", "Bar"
Error
    at new TokenImpl (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:45:18)
    at createToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:55:10)
    at Module../src/main.js (/Users/lhorie/Documents/aaa/src/main.js:10:1)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)
    at fn (/Users/lhorie/Documents/aaa/webpack/bootstrap:59:1)
    at Module../node_modules/fusion-cli/entries/server-entry.js (/Users/lhorie/Documents/aaa/node_modules/fusion-cli/entries/server-entry.js:46:1)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)
    at fn (/Users/lhorie/Documents/aaa/webpack/bootstrap:59:1)
    at Object.0 (/Users/lhorie/Documents/aaa/.fusion/dist/development/server/server-main.js:1518:18)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)

Different tokens with the same name were detected:

A
Error
    at new TokenImpl (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:45:18)
    at createToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:55:10)
    at Module../src/main.js (/Users/lhorie/Documents/aaa/src/main.js:9:1)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)
    at fn (/Users/lhorie/Documents/aaa/webpack/bootstrap:59:1)
    at Module../node_modules/fusion-cli/entries/server-entry.js (/Users/lhorie/Documents/aaa/node_modules/fusion-cli/entries/server-entry.js:46:1)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)
    at fn (/Users/lhorie/Documents/aaa/webpack/bootstrap:59:1)
    at Object.0 (/Users/lhorie/Documents/aaa/.fusion/dist/development/server/server-main.js:1518:18)
    at __webpack_require__ (/Users/lhorie/Documents/aaa/webpack/bootstrap:682:1)

You may have multiple versions of the same plugin installed.
Ensure that `yarn list [the-plugin]` results in one version, and use a yarn resolution or merge package version in your lock file to consolidate versions.


    at resolveToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/src/base-app.js:164:17)
    at resolvePlugin (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:522:31)
    at resolveToken (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:538:20)
    at App.resolve (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:568:7)
    at App.resolve (/Users/lhorie/Documents/aaa/node_modules/fusion-core/src/server-app.js:25:12)
    at App.callback (/Users/lhorie/Documents/aaa/node_modules/fusion-core/dist/index.js:877:12)
    at reload (/Users/lhorie/Documents/aaa/node_modules/fusion-cli/entries/server-entry.js:90:1)
    at 
    at process._tickCallback (internal/process/next_tick.js:189:7)
    at evalScript (bootstrap_node.js:482:13)
```