### PR TITLE
Freeze TokenType enum map for Flow

### DIFF
--- a/src/create-token.js
+++ b/src/create-token.js
@@ -8,10 +8,10 @@
 
 import type {Token} from './types.js';
 
-export const TokenType = {
+export const TokenType = Object.freeze({
   Required: 0,
   Optional: 1,
-};
+});
 function Ref() {}
 export class TokenImpl<TResolved> {
   name: string;


### PR DESCRIPTION
`$Values<>` only works like an enum type when the object is frozen.

https://flow.org/try/#0MYewdgzgLgBAcgeQCoH0CicCqBZGBeGAbwCgYYBBALhgHIBDGgGlJgCFqaAjJ4gXwG5iUAJ4AHAKbwQUNGACuAW3wwAJADU6AGzniIAHhESQAM3jJ0WbAD5BxUJFgYcyhJwBW44FAB0xgE7i4gBe4gAUJGRUtAzMZOy03My8AJSChpKyisrqWjr66SYwTta29tAwYNKZCtRwVfJKBDTANIJlsP4gIWDV1NXKza3EQA