### PR TITLE
set koa proxy:true in production env

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -587,3 +587,16 @@ test('app handles no render token', async t => {
     t.end();
   }
 });
+
+test('proxy flag false by default', async t => {
+  const flags = {render: false};
+  const element = 'hi';
+  const render = () => {
+    flags.render = true;
+    return 'lol';
+  };
+  const app = new App(element, render);
+  // $FlowFixMe
+  t.equal(app._app.proxy, false, 'fusion proxy should be false by default');
+  t.end();
+});

--- a/src/server-app.js
+++ b/src/server-app.js
@@ -18,15 +18,18 @@ import {
 } from './tokens';
 import ssrPlugin from './plugins/ssr';
 import contextMiddleware from './plugins/server-context.js';
+import getEnv from './get-env.js';
 
 export default function(): typeof BaseApp {
   const Koa = require('koa');
+  const envVars = getEnv();
 
   return class ServerApp extends BaseApp {
     _app: Koa;
     constructor(el, render) {
       super(el, render);
       this._app = new Koa();
+      this._app.proxy = envVars.env === 'production';
       this.middleware(contextMiddleware);
       this.register(TimingToken, Timing);
       this.middleware(


### PR DESCRIPTION
This would enable koa to use x-forwarded-for header to populate ctx.ip when behind proxy servers like nginx.