### PR TITLE
Allow orphan plugins when registered with a plugin enhancer

### DIFF
--- a/src/__tests__/enhance.js
+++ b/src/__tests__/enhance.js
@@ -63,6 +63,49 @@ tape('enhancement with a plugin', t => {
   app.resolve();
 });
 
+tape('enhancement with a plugin allows orphan plugins', t => {
+  const app = new App('el', el => el);
+
+  type FnType = string => string;
+  const FnToken: Token<FnType> = createToken('FnType');
+  const BaseFn: FnType = a => a;
+  const BaseFnEnhancer = (fn: FnType): FusionPlugin<void, FnType> => {
+    return createPlugin({
+      provides: () => {
+        return arg => {
+          return fn(arg) + ' enhanced';
+        };
+      },
+    });
+  };
+  app.register(FnToken, BaseFn);
+  app.enhance(FnToken, BaseFnEnhancer);
+  t.doesNotThrow(() => {
+    app.resolve();
+  });
+  t.end();
+});
+
+tape(
+  'enhancement with a non-plugin enhancer does not allow orphan plugins',
+  t => {
+    const app = new App('el', el => el);
+
+    type FnType = string => string;
+    const FnToken: Token<FnType> = createToken('FnType');
+    const BaseFn: FnType = a => a;
+    const BaseFnEnhancer = (fn: FnType): FnType => {
+      return fn;
+    };
+    app.register(FnToken, BaseFn);
+    app.enhance(FnToken, BaseFnEnhancer);
+    t.throws(() => {
+      app.resolve();
+    });
+    t.end();
+  }
+);
+
 tape('enhancement with a plugin with deps', t => {
   const app = new App('el', el => el);
 

--- a/src/base-app.js
+++ b/src/base-app.js
@@ -262,6 +262,8 @@ class FusionApp {
           let nextProvides = e(provides);
           appliedEnhancers.push([e, nextProvides]);
           if (nextProvides && nextProvides.__plugin__) {
+            // if the token has a plugin enhancer, allow it to be registered with no dependents
+            nonPluginTokens.delete(token);
             if (nextProvides.deps) {
               Object.values(nextProvides.deps).forEach(token =>
                 this._dependedOn.add(getTokenRef(token))


### PR DESCRIPTION
This is useful in situations where the default value on a token
does not provide plugin functionality (ex: middleware) but an
enhancer wishes to add this functionality.