### PR TITLE
Resolve timing.end on errored requests

### DIFF
--- a/src/__tests__/timing.js
+++ b/src/__tests__/timing.js
@@ -65,12 +65,15 @@ test('timing plugin on error middleware', async t => {
       t.equal(resolved.downstream, false, 'does not resolve downstream');
       t.equal(resolved.render, false, 'does not resolve render');
       t.equal(resolved.upstream, false, 'does not resolve upstream');
+      t.equal(ctx.status, 500, 'sets ctx.status');
       t.end();
     });
     return next();
   });
   app.middleware((ctx, next) => {
-    throw new Error('fail request');
+    const e = new Error('fail request');
+    e.status = 500;
+    throw e;
   });
   await run(app).catch(e => {});
 });

--- a/src/__tests__/timing.js
+++ b/src/__tests__/timing.js
@@ -72,6 +72,7 @@ test('timing plugin on error middleware', async t => {
   });
   app.middleware((ctx, next) => {
     const e = new Error('fail request');
+    // $FlowFixMe
     e.status = 500;
     throw e;
   });

--- a/src/plugins/timing.js
+++ b/src/plugins/timing.js
@@ -52,12 +52,20 @@ function middleware(ctx, next) {
     downstream: downstream.promise,
     upstream: upstream.promise,
   };
-  return next().then(() => {
-    const upstreamTime = now() - timing.from(ctx).upstreamStart;
-    upstream.resolve(upstreamTime);
-    const endTime = now() - ctx.timing.start;
-    end.resolve(endTime);
-  });
+  return next()
+    .then(() => {
+      const upstreamTime = now() - timing.from(ctx).upstreamStart;
+      upstream.resolve(upstreamTime);
+      const endTime = now() - ctx.timing.start;
+      end.resolve(endTime);
+    })
+    .catch(e => {
+      // currently we only resolve upstream and downstream when the request does not error
+      // we should however always resolve the request end timing
+      const endTime = now() - ctx.timing.start;
+      end.resolve(endTime);
+      throw e;
+    });
 }
 
 export default createPlugin({

--- a/src/plugins/timing.js
+++ b/src/plugins/timing.js
@@ -62,6 +62,10 @@ function middleware(ctx, next) {
     .catch(e => {
       // currently we only resolve upstream and downstream when the request does not error
       // we should however always resolve the request end timing
+      if (e && e.status) {
+        // this ensures any logging / metrics based on ctx.status will recieve the correct status code
+        ctx.status = e.status;
+      }
       const endTime = now() - ctx.timing.start;
       end.resolve(endTime);
       throw e;


### PR DESCRIPTION
We should always resolve timing.end, even if the request
errors (via ctx.throw for example).