### PR TITLE
Fix aliasing with optional tokens

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -92,7 +92,7 @@ class FusionApp {
     const alias = (sourceToken: *, destToken: *) => {
       this._dependedOn.add(getTokenRef(destToken));
       if (aliases) {
-        aliases.set(sourceToken, destToken);
+        aliases.set(getTokenRef(sourceToken), destToken);
       }
       return {alias};
     };
@@ -140,8 +140,8 @@ class FusionApp {
     const appliedEnhancers = [];
     const resolveToken = (token: Token<TResolved>, tokenAliases) => {
       // Base: if we have already resolved the type, return it
-      if (tokenAliases && tokenAliases.has(token)) {
-        const newToken = tokenAliases.get(token);
+      if (tokenAliases && tokenAliases.has(getTokenRef(token))) {
+        const newToken = tokenAliases.get(getTokenRef(token));
         if (newToken) {
           token = newToken;
         }


### PR DESCRIPTION
Previously to alias an optional dependency of a plugin, one would have to alias the "optional type token" given the alias map key was `TokenImpl` instead of `Ref()`.

```js
app
  .register(PluginWithOptionalDep)
  .alias(OptionalDep.optional, AlternativeDep);
app.register(AlternativeDep, AlternativePlugin);
```

->

```js
app
  .register(PluginWithOptionalDep)
  .alias(OptionalDep, AlternativeDep);
app.register(AlternativeDep, AlternativePlugin);
```