### PR TITLE
Improve token tracking

### DIFF
--- a/src/base-app.js
+++ b/src/base-app.js
@@ -68,6 +68,10 @@ class FusionApp {
         },
       };
     }
+    token.stacks.push({type: 'register', stack: new Error().stack});
+    if (value && value.__plugin__) {
+      token.stacks.push({type: 'plugin', stack: value.stack});
+    }
     return this._register(token, value);
   }
   _register<TResolved>(token: Token<TResolved>, value: *) {
@@ -90,6 +94,9 @@ class FusionApp {
       token,
     });
     const alias = (sourceToken: *, destToken: *) => {
+      const stack = new Error().stack;
+      sourceToken.stacks.push({type: 'alias-from', stack});
+      destToken.stacks.push({type: 'alias-to', stack});
       this._dependedOn.add(getTokenRef(destToken));
       if (aliases) {
         aliases.set(getTokenRef(sourceToken), destToken);
@@ -105,6 +112,7 @@ class FusionApp {
     this.register(createPlugin({deps, middleware}));
   }
   enhance<TResolved>(token: Token<TResolved>, enhancer: Function) {
+    token.stacks.push({type: 'enhance', stack: new Error().stack});
     const {value, aliases, enhancers} = this.registered.get(
       getTokenRef(token)
     ) || {

--- a/src/create-plugin.js
+++ b/src/create-plugin.js
@@ -19,6 +19,7 @@ export function createPlugin<TDeps, TService>(
 ): FusionPlugin<TDeps, TService> {
   return {
     __plugin__: true,
+    stack: new Error().stack,
     ...opts,
   };
 }

--- a/src/create-token.js
+++ b/src/create-token.js
@@ -18,13 +18,13 @@ export class TokenImpl<TResolved> {
   ref: mixed;
   type: $Values<typeof TokenType>;
   optional: ?TokenImpl<TResolved>;
-  stack: string;
+  stacks: Array<string>;
 
   constructor(name: string, ref: mixed) {
     this.name = name;
     this.ref = ref || new Ref();
     this.type = ref ? TokenType.Optional : TokenType.Required;
-    this.stack = new Error().stack;
+    this.stacks = [{type: 'token', stack: new Error().stack}];
     if (!ref) {
       this.optional = new TokenImpl(name, this.ref);
     }


### PR DESCRIPTION
Rationale: fusion-plugin-introspect currently collects data about where a token was created. While this is useful, it's not as useful as it could be. This diff allows a token to track:

- where the token was created
- where it was registered
- what plugin was registered with it
- where it was enhanced
- where it was aliased to another token
- where it was aliased from another token

This information will allows us to surface a far more comprehensive picture of how dependencies in the DI graph are setup and used.