### PR TITLE
Remove fusion-cli peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "ua-parser-js": "^0.7.19",
     "uuid": "^3.3.2"
   },
-  "peerDependencies": {
-    "fusion-cli": "^1.9.0"
-  },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",


### PR DESCRIPTION
`fusion-cli` doesn't appear to be actually used anywhere in `fusion-core`

This PR removes it from package.json.

Rationale: fusion-cli depends on fusion-core, so we want to avoid having fusion-core cyclically depend on fusion-cli in order to allow the two to co-exist in a monorepo where fusion co-dependencies are linked together via symlinks or similar mechanisms. Cyclical dependencies cause problems for tooling that relies on file system traversal, and need to be avoided.