### PR TITLE
Upgrade flow-bin to latest and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^22.1.2",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.91.0",
+    "flow-bin": "^0.92.0",
     "node-fetch": "^2.3.0",
     "nyc": "^13.1.0",
     "prettier": "^1.15.3",

--- a/src/__tests__/sanitization.node.js
+++ b/src/__tests__/sanitization.node.js
@@ -33,7 +33,7 @@ test('html sanitization works', async t => {
   const userData = '<malicious data="" />';
   const value = html`
     <div>${userData}</div>
-    ${null}
+    ${String(null)}
   `;
   t.equals(typeof value, 'object');
   t.equals(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.91.0:
-  version "0.91.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.91.0.tgz#f5c89729f74b2ccbd47df6fbfadbdcc89cc1e478"
-  integrity sha512-j+L+xNiUYnZZ27MjVI0y2c9474ZHOvdSQq0Tjwh56mEA7tfxYqp5Dcb6aZSwvs3tGMTjCrZow9aUlZf3OoRyDQ==
+flow-bin@^0.92.0:
+  version "0.92.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.92.0.tgz#f5bf3e808b17b480e067ac673829ca715a168bea"
+  integrity sha512-3ErXSAXZZlLV5/QPlaUDCWlDUXop1SiH32ifXL3SEiBwsmGbudCLim+HFVZfkegrn1nB4TcNSkMWtW8SnMPyAQ==
 
 for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
Upgrades `flow-bin` to `v0.92.0` and resolves the following complaint:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/sanitization.node.js:36:12

Cannot call null.toString because property toString is missing in null [1].

     33│   const userData = '<malicious data="" />';
     34│   const value = html`
     35│     <div>${userData}</div>
 [1] 36│     ${null.toString()}
     37│   `;
     38│   t.equals(typeof value, 'object');
     39│   t.equals(



Found 1 error
```