### PR TITLE
Fix SSR Decider for Bots

### DIFF
--- a/src/__tests__/app.node.js
+++ b/src/__tests__/app.node.js
@@ -24,6 +24,7 @@ test('context composition', async t => {
   chunkIdZero.set('es5', 'es5-file.js');
   chunkUrlMap.set(0, chunkIdZero);
   const context = {
+    method: 'GET',
     headers: {accept: 'text/html'},
     path: '/',
     syncChunks: [0],
@@ -66,6 +67,7 @@ test('context composition with a cdn', async t => {
   chunkIdZero.set('es5', 'es5-file.js');
   chunkUrlMap.set(0, chunkIdZero);
   const context = {
+    method: 'GET',
     headers: {accept: 'text/html'},
     path: '/',
     syncChunks: [0],

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -130,6 +130,7 @@ test('ssr with bot user agent', async t => {
     // $FlowFixMe
 
     let initialCtx = {
+      method: 'GET',
       headers: {
         accept: '*/*',
         'user-agent': 'AdsBot-Google',
@@ -147,6 +148,39 @@ test('ssr with bot user agent', async t => {
   t.end();
 });
 
+test('POST request with bot user agent', async t => {
+  const flags = {render: false};
+  const element = 'hi';
+  const render = () => {
+    flags.render = true;
+    return 'lol';
+  };
+  const app = new App(element, render);
+
+  app.middleware(async (ctx, next) => {
+    t.notOk(ctx.element, 'does not set ctx.element');
+    ctx.body = 'OK';
+    await next();
+  });
+  try {
+    let initialCtx = {
+      method: 'POST',
+      headers: {
+        accept: '*/*',
+        'user-agent': 'AdsBot-Google',
+      },
+    };
+    // $FlowFixMe
+    const ctx = await run(app, initialCtx);
+    t.notOk(ctx.rendered, 'does not set ctx.rendered');
+    t.equal(ctx.body, 'OK', 'sets ctx.body');
+    t.equal(flags.render, false, 'does not call render');
+  } catch (e) {
+    t.ifError(e, 'should not error');
+  }
+  t.end();
+});
+
 test('ssr without valid accept header', async t => {
   const flags = {render: false};
   const element = 'hi';
@@ -155,6 +189,7 @@ test('ssr without valid accept header', async t => {
   };
   const app = new App(element, render);
   let initialCtx = {
+    method: 'GET',
     headers: {accept: '*/*'},
   };
   try {
@@ -179,6 +214,7 @@ test('ssr without valid bot user agent', async t => {
   };
   const app = new App(element, render);
   let initialCtx = {
+    method: 'GET',
     headers: {
       accept: '*/*',
       'user-agent': 'test',
@@ -232,6 +268,7 @@ test('disable SSR by composing SSRDecider with a plugin', async t => {
 
   try {
     let initialCtx = {
+      method: 'GET',
       path: '/foo',
     };
     // $FlowFixMe
@@ -278,6 +315,7 @@ test('disable SSR by composing SSRDecider with a function', async t => {
 
   try {
     let initialCtx = {
+      method: 'GET',
       path: '/foo',
     };
     // $FlowFixMe
@@ -327,6 +365,7 @@ test('SSR extension handling', async t => {
     for (let i in extensionToSSRSupported) {
       flags.render = false;
       let initialCtx = {
+        method: 'GET',
         path: `/some-path.${i}`,
       };
       // $FlowFixMe

--- a/src/__tests__/test-helper.js
+++ b/src/__tests__/test-helper.js
@@ -30,6 +30,7 @@ function getContext() {
   return __BROWSER__
     ? {}
     : {
+        method: 'GET',
         path: '/',
         headers: {
           accept: 'text/html',

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -25,7 +25,7 @@ const SSRDecider = createPlugin<{}, SSRDeciderService>({
       // Bots don't always include the accept header.
       if (ctx.headers['user-agent']) {
         const agent = ctx.headers['user-agent'];
-        if (botRegex.test(agent)) {
+        if (botRegex.test(agent) && ctx.method === 'GET') {
           return true;
         }
       }


### PR DESCRIPTION
Previously we were returning true from the SSRDecider for all requests with a
user agent matching a bot. This caused issues when handling non GET routes.
This updates the logic to also check for the request method === GET.