### PR TITLE
Include svg and js.map in the extension list determining SSR

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -341,6 +341,8 @@ test('disable SSR by composing SSRDecider with a function', async t => {
 
 test('SSR extension handling', async t => {
   const extensionToSSRSupported = {
+    'js.map': false,
+    svg: false,
     js: false,
     gif: false,
     jpg: false,

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -20,7 +20,8 @@ const SSRDecider = createPlugin<{}, SSRDeciderService>({
     return ctx => {
       // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
       // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
-      if (ctx.path.match(/\.(js|gif|jpg|png|pdf|json|svg)$/)) return false;
+      if (ctx.path.match(/\.(js|js\.map|gif|jpg|png|pdf|json|svg)$/))
+        return false;
 
       // Bots don't always include the accept header.
       if (ctx.headers['user-agent']) {

--- a/src/plugins/ssr.js
+++ b/src/plugins/ssr.js
@@ -20,7 +20,7 @@ const SSRDecider = createPlugin<{}, SSRDeciderService>({
     return ctx => {
       // If the request has one of these extensions, we assume it's not something that requires server-side rendering of virtual dom
       // TODO(#46): this check should probably look at the asset manifest to ensure asset 404s are handled correctly
-      if (ctx.path.match(/\.(js|gif|jpg|png|pdf|json)$/)) return false;
+      if (ctx.path.match(/\.(js|gif|jpg|png|pdf|json|svg)$/)) return false;
 
       // Bots don't always include the accept header.
       if (ctx.headers['user-agent']) {


### PR DESCRIPTION
This will ensure svg and sourcemap asset requests will not result in an SSR being triggered